### PR TITLE
The document writer lends a grown entry's prefix only to an adapter that read the leaf from zero; the dead offsets reader goes; the reference names every offsets path (T396 follow-up)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1572,8 +1572,10 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   `rewrite`, `guard`, `identity`, `corrupt`, `restore`), `skipped` per reason
   (`noEntry`, `restored`, `written`, `noBoundary`, `unsplittable`,
   `reconstruction`, `oversize`, `unencodable`, `offsets`, `stat`, `write`;
-  `offsets` is a reader entry holding fewer records than the tree read, or
-  more for a lineage file or under another generation: a LEAF entry that
+  `offsets` is no reader entry at all, a tail entry (one read from a
+  checkpoint's offset, its base above zero), or an entry holding fewer records
+  than the tree read, or more for a lineage file or under another generation
+  or over a base the tree's adapter did not read from zero: a LEAF entry that
   merely grew since the settle's parse lends the prefix the tree read, so a
   busy session's document is written between its appends; a lineage file's
   skip row carries the stat of the records the tree was parsed from, so a

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -1609,18 +1609,6 @@ def _entry_offsets_gen(path):
     return [(offs[i], offs[i + 1]) for i in range(0, len(offs), 2)], ent[6]
 
 
-def record_offsets(path, base):
-    """[(byte offset, byte length)] of the reader entry's held records for `path`, record `base` first (the entry's
-    base): the assembly checkpoint's record locations. None when the reader holds no entry or its base is later."""
-    with _JSONL_CACHE_LOCK:
-        ent = _JSONL_CACHE.get(str(path))
-    if ent is None or len(ent) < 8 or ent[5] > base:
-        return None
-    offs = ent[7]
-    start = (base - ent[5]) * 2
-    return [(offs[i], offs[i + 1]) for i in range(start, len(offs), 2)]
-
-
 def _read_jsonl_incremental(path, on_fail=None):
     """The parsed records of `path` (a list, NOT a generator), served append-incrementally per the cache
     contract above. Falls back to a full read on any surprise; [] on any error, like _read_jsonl. `on_fail`,
@@ -5270,8 +5258,12 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None, reason
             # (round one, medium): its row would be a skip row proven by a stat alone, and a prior file that gained a record
             # after the parse (its own session resumed elsewhere, the case _asm_gates demotes as nonleaf) would be stamped
             # as wholly before the cut with the appended record missing from every restore of this leaf's kernel life.
-            src_gen = (getattr(ad, "_src_keys", {}) or {}).get(fp, (None,))[0]
-            if offs is None or len(offs) < len(recs) or (len(offs) > len(recs) and not (is_leaf and src_gen == ent_gen)):
+            src_gen, src_base = ((getattr(ad, "_src_keys", {}) or {}).get(fp, (None, None)) + (None, None))[:2]
+            # The prefix is accepted for the leaf under the tree's own generation AND from base zero: a seeded adapter that
+            # read the file from its cut (a degenerate document whose pre-cut part holds records but no atoms restores unseen
+            # as restored) holds records the entry's prefix does not begin with, so a whole reader upgrading the entry to
+            # base zero under the same generation must not lend it that prefix (round two, low 1).
+            if offs is None or len(offs) < len(recs) or (len(offs) > len(recs) and not (is_leaf and src_gen == ent_gen and src_base == 0)):
                 return skip("offsets")
             offs = offs[:len(recs)]                       # defensive: no row index below passes len(recs), so the extra
             file_offs[fp] = offs                          #  offsets of a grown entry are never read (round one, low 3)

--- a/tests/test_asm_checkpoint.py
+++ b/tests/test_asm_checkpoint.py
@@ -558,7 +558,7 @@ class ConvergeAssembly(Harness):
     def test_the_dirty_leaf_boot_shape_writes_the_fold_document_and_the_assembly_document_in_one_pass(self):
         """Round one, medium: the ordinary boot shape is a dirty idle leaf (the judges' pass read it whole, its fold document lacks
         the pairing) with no assembly document. The fold half of the pass healed and primed it and its held quiescence drop
-        POPPED the record entry; the assembly step then found the assembly entry but no record entry (record_offsets None), a
+        POPPED the record entry; the assembly step then found the assembly entry but no record entry (_entry_offsets_gen (None, None)), a
         skipped write, retried once, abandoned. The assembly write now runs while the record entry is resident, inside the same
         hold, and the held drop is paid after it: one pop, both documents from the one read, and the next boot restores both."""
         path = self.idle_leaf("both")

--- a/tests/test_asm_write_over_grown_entry.py
+++ b/tests/test_asm_write_over_grown_entry.py
@@ -147,6 +147,37 @@ class WriteOverGrownEntry(Harness):
         self.assertEqual(ad._src_stat[str(pa)], (row["size"], row["mtime"]), "the adapter holds it for the next write")
         self.assertEqual(ad._src_keys[str(pa)], ("skip",))
 
+    def test_a_prefix_is_lent_only_to_an_adapter_that_read_from_zero(self):
+        """Round two, low 1: the prefix clause proved the generation but not the adapter's BASE. A degenerate document whose
+        pre-cut part holds records but no atoms (two reminder attachments, then the boundary as the first atom) restores with
+        prefix 0, so the writer does not see the tree as restored and runs over a seeded adapter that read from the cut
+        (base 2); a whole reader under another key then upgrades the entry to base 0 under the same generation, and the
+        writer accepted that prefix over records the adapter never read. The prefix is the leaf's, under the tree's
+        generation, from base zero."""
+        t0 = NOW
+        recs = [G.reminder_line(t0, "att_deg_1", None),                     # uuid-chained attachments that are never atoms
+                G.reminder_line(t0 + 1, "att_deg_2", "att_deg_1"),
+                G.compact_line(t0 + 10, "b_deg", "att_deg_2"),
+                G.compact_summary_line(t0 + 11, "s_deg", "b_deg"),
+                G.uline(t0 + 20, "after the compaction, what remains?", "u_deg_1", "s_deg"),
+                G.aline(t0 + 30, "the cap and the retry budget remain", "a_deg_1", "u_deg_1", stop="end_turn"),
+                G.uline(t0 + 40, "then close them out", "u_deg_2", "a_deg_1"),
+                G.aline(t0 + 50, "closing both", "a_deg_2", "u_deg_2", stop="end_turn")]
+        path = self.write("degenerate", recs)
+        self.fresh(); self.parse(path)
+        self.assertTrue(self.doc(path), em.asm_checkpoint_stats())
+        doc = json.load(gzip.open(em._asm_ckpt_file(path)))
+        row = doc["files"][os.path.basename(path)[:-6]]
+        self.assertEqual(row["cut"][1], 2, "the cut sits after the two attachment records: %r" % (row["cut"][:2],))
+        self.fresh(); modes = []
+        tree = self.parse(path, modes)                                  # a seeded adapter reading from the cut: base 2
+        self.assertEqual(modes, ["restore"])
+        em._read_jsonl_entry(path, tail_ok=False)                        # a whole reader under another key: base 0, same generation
+        em._ASM_CKPT_STATS["skipped"] = {}
+        reasons = []
+        self.assertFalse(em.asm_checkpoint_write(path, SID, False, tree=tree, reason_out=reasons), "not lent: %r" % reasons)
+        self.assertEqual(reasons, ["offsets"], "%r" % reasons)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lazy_body_readers.py
+++ b/tests/test_lazy_body_readers.py
@@ -50,7 +50,7 @@ EVENT_MODEL_ALLOWED = {
     "chain_membership", "file_rewound", "_membership_of", "_seed_from_doc", "_entry_current", "_carry_encode", "_carry_decode",
     "_LazyBody", "_LazyBody._refuse", "_Unhydrated", "_ckpt_encode", "_ckpt_decode", "_fold_eof_fragment", "_trailing_record",
     "_atom_line", "_dump",                              # the module's own --test dump over a whole parse (never a restored tree)
-    "fold_records", "_read_jsonl_entry_unlocked", "_read_jsonl_entry", "record_offsets", "_scan_jsonl_bytes", "resume_fork_links",
+    "fold_records", "_read_jsonl_entry_unlocked", "_read_jsonl_entry", "_scan_jsonl_bytes", "resume_fork_links",
     "_lineage_closure", "_load_states", "_read_jsonl", "_read_jsonl_incremental", "_tail_read", "_pinned_entry",
 }
 SDK_BACKEND_ALLOWED = None        # the backend builds live atoms and reads raw records only: every site allowed, listed for the record


### PR DESCRIPTION
Fix tier: three review lows on the document writer's grown-entry rule (the previous change), the first with a test that fails before it.

**Low 1, the adapter's base.** The prefix clause proved the entry's generation but not that the tree's adapter read the file from record zero. A degenerate document whose pre-cut part holds records but no atoms (two reminder attachments, then the boundary as the first atom) restores with an empty prefix, so the writer does not see the tree as restored and runs over a seeded adapter that read from the cut; a whole reader under another key then upgrades the entry to base zero under the same generation, and the writer accepted that prefix over records the adapter never read. The accept condition now requires the adapter's base to be zero.

**Low 2.** `record_offsets` was dead production code after the one-lock helper; removed, with its test allowlist slot and the one comment naming it.

**Low 3.** The reference's `offsets` sentence names every path of the skip: no reader entry, a tail entry with its base above zero, fewer records than the tree, more for a lineage file, another generation, or a base the adapter did not read from zero.

**Test** (`tests/test_asm_write_over_grown_entry.py`): the degenerate document written and restored, the entry upgraded by a whole reader, the write refused with `offsets`. At the base it is written: "True is not false : not lent: []".

🤖 Generated with [Claude Code](https://claude.com/claude-code)