### PR TITLE
The pusher keeps each cycle's stage split: the boot's first cycle for the process and the last cycles in a memory-fraction ring, under the perf pusher block and the boot-health row (T397)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1515,6 +1515,22 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   longer wait between cycles would have skipped; a conservative undercount,
   since a wake set by another thread or a periodic repost of an unchanged
   frame marks a cycle busy).
+  `firstCycle` and `stageRing` (T397): the boot's first pusher cycle's stage
+  split and the newest cycles' splits, each `{s, t, stages}` with, per stage,
+  its wall `ms` (one decimal), the reader's `bytes` off disk and the assembly
+  cut's `hydrated` bytes ON THE PUSHER'S THREAD since the previous stage
+  boundary (another thread's reads in the window, the judges' first pass or
+  a boot warm, are not the pusher's; a dashboard's connect push, which runs
+  the same stages on the HTTP handler thread, feeds `stages_ms` and never the
+  split); the `push` container carries its sub-stages' sums, the jobs before
+  the push land in `jobs`, and the boundary sits at the push's entry, before
+  the cards-first path. A plain GET carries the newest 16 splits and
+  `stageRingLen`; `GET /perf?ring=all` carries the whole ring, which holds
+  `stageRingMax` cycles: `ROMP_PERF_STAGE_RING` when set, else one per 64 MiB
+  of the machine's memory floored at 16, resolved once, never a literal
+  count. The restart ledger's boot-health row carries the first cycle's
+  `stages` beside `firstCycleS`, so a slow boot names its stage without the
+  kernel alive.
 - `checkpoints`: the folds' checkpoints since boot: `restored` (files whose
   folds resumed from one), `restoredFolds` (restores per fold name), `writes`,
   `swept` (checkpoints of vanished files removed at boot), `refolds` (per fold
@@ -1626,15 +1642,6 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   (every hit). The acceptance number of the lazy-transcript work: a boot with
   no client connected reads `kernel` zero, and a connecting chat client adds
   at most its shown tabs.
-  `firstCycle` and `stageRing` (T397): the boot's first cycle's stage split
-  and the last cycles' splits, each `{s, t, stages}` with, per stage, its wall
-  `ms`, the reader's `bytes` off disk and the assembly cut's `hydrated` bytes
-  since the previous stage boundary (the `push` container carries its
-  sub-stages' sums; the jobs before the push land in `jobs`); the ring holds
-  `stageRingMax` cycles, one per 64 MiB of the machine's memory floored at
-  16, never a literal count. The restart ledger's boot-health row carries the
-  first cycle's `stages` beside `firstCycleS`, so a slow boot names its stage
-  without the kernel alive.
 - `stages_ms`: `jobs` (the cycle's tick jobs outside the push), `push`, and
   inside it `push.chat`, `push.feed`, `push.timeline`, `push.send`. The
   `push.*` stages count every push, including the one a connecting page gets,

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1626,6 +1626,15 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   (every hit). The acceptance number of the lazy-transcript work: a boot with
   no client connected reads `kernel` zero, and a connecting chat client adds
   at most its shown tabs.
+  `firstCycle` and `stageRing` (T397): the boot's first cycle's stage split
+  and the last cycles' splits, each `{s, t, stages}` with, per stage, its wall
+  `ms`, the reader's `bytes` off disk and the assembly cut's `hydrated` bytes
+  since the previous stage boundary (the `push` container carries its
+  sub-stages' sums; the jobs before the push land in `jobs`); the ring holds
+  `stageRingMax` cycles, one per 64 MiB of the machine's memory floored at
+  16, never a literal count. The restart ledger's boot-health row carries the
+  first cycle's `stages` beside `firstCycleS`, so a slow boot names its stage
+  without the kernel alive.
 - `stages_ms`: `jobs` (the cycle's tick jobs outside the push), `push`, and
   inside it `push.chat`, `push.feed`, `push.timeline`, `push.send`. The
   `push.*` stages count every push, including the one a connecting page gets,

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -745,18 +745,31 @@ _READ_BYTES_LOCK = threading.Lock()
 
 
 _READ_BYTES_TOTAL = [0]           # the reader's bytes off disk since the process began, one integer (T397: a stage mark)
+_THREAD_BYTES = threading.local()  # the same, per THREAD (`read`, `hydrated`): the pusher's stage split reads its own thread's
 
 
 def _count_read(path, n):
     with _READ_BYTES_LOCK:
         _READ_BYTES[path] = _READ_BYTES.get(path, 0) + int(n)
         _READ_BYTES_TOTAL[0] += int(n)
+    _THREAD_BYTES.read = getattr(_THREAD_BYTES, "read", 0) + int(n)
 
 
 def read_bytes_total():
     """What the reader pulled off disk since the process began, as one number (the per-path table is read_bytes_report)."""
     with _READ_BYTES_LOCK:
         return _READ_BYTES_TOTAL[0]
+
+
+def thread_read_bytes():
+    """What the reader pulled off disk on the CALLING thread since it began (T397 round one, low 2: a stage's bytes are the
+    pusher's own, not the judges' first pass or a boot warm reading through the same window)."""
+    return getattr(_THREAD_BYTES, "read", 0)
+
+
+def thread_hydrated_bytes():
+    """The assembly cut's hydrated bytes on the CALLING thread since it began (the process total is asmCheckpoint.hydratedBytes)."""
+    return getattr(_THREAD_BYTES, "hydrated", 0)
 
 
 def read_bytes_report():
@@ -5979,6 +5992,7 @@ def hydrate(atoms, rompuuid=None, by=None):
                     raise LazyBodyRead("atom %s: the record at its offset is %s" % (a.get("uuid"), rec.get("uuid")))
                 with _ASM_CKPT_LOCK:
                     _ASM_CKPT_STATS["hydratedBytes"] += ln; _ASM_CKPT_STATS["hydratedAtoms"] += 1
+                    _THREAD_BYTES.hydrated = getattr(_THREAD_BYTES, "hydrated", 0) + ln   # this thread's share (T397)
                     _ASM_CKPT_STATS["hydratedBy"][by] = _ASM_CKPT_STATS["hydratedBy"].get(by, 0) + ln
                     if a.get("uuid"):
                         _HYDRATED[a["uuid"]] = (rec, ln); _HYDRATED_BYTES[0] += ln

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -744,9 +744,19 @@ _READ_BYTES = {}                  # path -> bytes this process read from it thro
 _READ_BYTES_LOCK = threading.Lock()
 
 
+_READ_BYTES_TOTAL = [0]           # the reader's bytes off disk since the process began, one integer (T397: a stage mark)
+
+
 def _count_read(path, n):
     with _READ_BYTES_LOCK:
         _READ_BYTES[path] = _READ_BYTES.get(path, 0) + int(n)
+        _READ_BYTES_TOTAL[0] += int(n)
+
+
+def read_bytes_total():
+    """What the reader pulled off disk since the process began, as one number (the per-path table is read_bytes_report)."""
+    with _READ_BYTES_LOCK:
+        return _READ_BYTES_TOTAL[0]
 
 
 def read_bytes_report():

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -204,6 +204,14 @@ _CHAT_SIG_LABELS = ("transcript", "states", "store", "hold", "archive", "episode
 _CHAT_SIG_DEPS = ("taskout", "pathlink", "postal")
 
 
+def _stage_ring_len(mem_total=None):
+    """How many cycles' stage splits the pusher keeps (T397): one per 64 MiB of the machine's memory, floored at 16 (a
+    64 GB box keeps 1024 cycles, a 4 GB one 64; an entry is a few hundred bytes), never a literal count (the user's
+    caches direction 2026-09-11). `mem_total` overrides the machine's reading (tests)."""
+    total = _mem_total_bytes() if mem_total is None else int(mem_total)
+    return max(16, total // (64 * 1024 * 1024))
+
+
 class _PerfStats:
     """Always-on counters behind GET /perf (`romp perf`): where the kernel's threads spend their time,
     kept cheap enough to leave running. Every writer takes the lock and does a few dict operations;
@@ -323,6 +331,15 @@ class _PerfStats:
                            "idle_cycles": 0, "idle_ms_sum": 0.0, "idle_cpu_ms_sum": 0.0}
             self.ring = collections.deque(maxlen=self.RING)
             self.stages = {k: 0.0 for k in self.STAGES}
+            # T397: the stage split PER CYCLE. `cycle_stages` fills as the cycle's stages close (wall ms, the reader's bytes
+            # and the hydrated bytes since the previous stage boundary); cycle() keeps the boot's FIRST cycle's split for
+            # the process (firstCycleS alone could not name the stage a 59 s boot spent its time in, 2026-09-12) and
+            # appends every cycle's split to `stage_ring`, a deque sized as a fraction of memory (_stage_ring_len), made
+            # at the first cycle since the memory reader is defined below this class.
+            self.cycle_stages = {}
+            self.first_cycle = None
+            self.stage_ring = None
+            self._stage_mark = None
             self.builds = {k: {"cached": 0, "built": 0, "ms": 0.0} for k in self.BUILDS}
             self.builds["chat"].update({"active_built": 0, "bg_built": 0, "moved": 0,
                                         "bg_miss": {k: 0 for k in self.CHAT_MISS}})   # see build_chat
@@ -401,10 +418,58 @@ class _PerfStats:
             if ms > p["cycle_ms_max"]:
                 p["cycle_ms_max"] = ms
             self.ring.append(ms)
+            split = {"s": round(dt, 3), "t": time.time(), "stages": self.cycle_stages}
+            if self.first_cycle is None:
+                self.first_cycle = split
+            if self.stage_ring is None:
+                self.stage_ring = collections.deque(maxlen=_stage_ring_len())
+            self.stage_ring.append(split)
+            self.cycle_stages = {}
+            self._stage_mark = None
+
+    @staticmethod
+    def _byte_marks():
+        """(the reader's bytes off disk, the assembly cut's hydrated bytes) so far: the two byte counters a stage moves."""
+        try:
+            return em.read_bytes_total(), int(em.asm_checkpoint_stats().get("hydratedBytes") or 0)
+        except Exception:
+            return 0, 0
+
+    def stage_boundary(self):
+        """A stage boundary that closes no stage: the bytes read since the last boundary belong to the stage that closes
+        next (the pusher's jobs before the push: `_push` marks its own start so its first sub-stage does not carry them)."""
+        marks = self._byte_marks()
+        with self.lock:
+            prev = self._stage_mark
+            self._stage_mark = marks
+            if prev is not None:                            # the jobs before the push: to the cycle's `jobs` bucket
+                cs = self.cycle_stages.setdefault("jobs", {"ms": 0.0, "bytes": 0, "hydrated": 0})
+                cs["bytes"] += max(0, marks[0] - prev[0]); cs["hydrated"] += max(0, marks[1] - prev[1])
 
     def stage(self, name, dt):
+        marks = self._byte_marks()
         with self.lock:
             self.stages[name] = self.stages.get(name, 0.0) + dt * 1000.0
+            cs = self.cycle_stages.setdefault(name, {"ms": 0.0, "bytes": 0, "hydrated": 0})
+            cs["ms"] += dt * 1000.0
+            if name == "push":                              # the container: its bytes are its sub-stages' (already attributed)
+                cs["bytes"] = sum(v["bytes"] for k, v in self.cycle_stages.items() if k.startswith("push."))
+                cs["hydrated"] = sum(v["hydrated"] for k, v in self.cycle_stages.items() if k.startswith("push."))
+            else:
+                prev = self._stage_mark
+                if prev is not None:
+                    cs["bytes"] += max(0, marks[0] - prev[0]); cs["hydrated"] += max(0, marks[1] - prev[1])
+                self._stage_mark = marks
+
+    def cycle_begin(self):
+        """The cycle's first byte mark: what the stages below it are measured from."""
+        marks = self._byte_marks()
+        with self.lock:
+            self._stage_mark = marks
+
+    def first_cycle_split(self):
+        with self.lock:
+            return dict(self.first_cycle) if self.first_cycle is not None else None
 
     def parse_hit(self):
         """The kernel's _parse served from the shared store (T323 stage 2)."""
@@ -516,6 +581,9 @@ class _PerfStats:
         with self.lock:
             ring = sorted(self.ring)
             pusher = dict(self.pusher)
+            pusher["firstCycle"] = dict(self.first_cycle) if self.first_cycle is not None else None   # T397: the boot's
+            pusher["stageRing"] = list(self.stage_ring) if self.stage_ring is not None else []          #  first cycle's split
+            pusher["stageRingMax"] = self.stage_ring.maxlen if self.stage_ring is not None else _stage_ring_len()   # and the ring
             stages = dict(self.stages)
             builds = {k: dict(v) for k, v in self.builds.items()}
             builds["chat"]["bg_miss"] = dict(self.builds["chat"]["bg_miss"])   # the nested map: a copy too
@@ -23228,6 +23296,9 @@ def _boot_health_first_cycle(dt):
     _BOOT_HEALTH_DONE[0] = True
     row = {"t": int(time.time()), "pid": os.getpid(), "bootHealth": True, "firstCycleS": round(dt, 2),
            "boundS": BOOT_FIRST_CYCLE_BOUND_S, "slow": dt > BOOT_FIRST_CYCLE_BOUND_S}
+    split = _PERF_STATS.first_cycle_split()                # T397: the cycle's stage split rides the row (the ledger reader
+    if split is not None:                                  #  sees which stage a slow boot spent its time in without the kernel)
+        row["stages"] = split.get("stages")
     if row["slow"]:
         try:
             sys.stderr.write("boot health: the first pusher cycle took %.1f s (bound %.0f s): sessions and cards waited behind it; "
@@ -46431,6 +46502,7 @@ def _push(targets, connect=False, live_map=None):
         # The FEED's per-session Fleet ledger slice still rides along, attached AFTER the builds (want_chat —
         # we do NOT build all sessions just for a feed/fleet push: the user 2026-06-24 slow-load regression).
         chat_sessions = []
+        _PERF_STATS.stage_boundary()          # T397: the push's sub-stages measure their bytes from here, not from the cycle's start
         _t_stage = time.monotonic()                      # /perf stage clock: chat, then feed, then timeline
         if want_chat or want_fleet:   # the fleet needs every session's ledger slice (built below, attached to feed)
             # TABS-FIRST (the user 2026-06-26): ship name+color per tab so the client can paint the WHOLE strip
@@ -49341,6 +49413,7 @@ def _pusher_cycle():
 
 def _pusher_cycle_jobs(now, live_map, any_client):
     _t_jobs = time.monotonic()            # /perf: this function minus the _push_all below is the `jobs` stage
+    _PERF_STATS.cycle_begin()             # T397: the cycle's first byte mark, so the split's bytes start here
     try:                                  # the cycle's checkpoint byte budget, whole again, and the drops owed from the last one
         _begin_checkpoint_cycle()         # (T362): before the builds below, whose quiescence drops write against it
     except Exception:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -204,12 +204,26 @@ _CHAT_SIG_LABELS = ("transcript", "states", "store", "hold", "archive", "episode
 _CHAT_SIG_DEPS = ("taskout", "pathlink", "postal")
 
 
+_STAGE_RING_LEN = [None]          # resolved once (the first cycle), like the other memory-fraction bounds' module constants
+
+
 def _stage_ring_len(mem_total=None):
-    """How many cycles' stage splits the pusher keeps (T397): one per 64 MiB of the machine's memory, floored at 16 (a
-    64 GB box keeps 1024 cycles, a 4 GB one 64; an entry is a few hundred bytes), never a literal count (the user's
-    caches direction 2026-09-11). `mem_total` overrides the machine's reading (tests)."""
-    total = _mem_total_bytes() if mem_total is None else int(mem_total)
-    return max(16, total // (64 * 1024 * 1024))
+    """How many cycles' stage splits the pusher keeps (T397): ROMP_PERF_STAGE_RING when it names a positive integer, else one
+    per 64 MiB of the machine's memory floored at 16 (a 64 GB box keeps 1024 cycles, a 4 GB one 64; an entry is about
+    2.5 KB, so the largest ring is a few MB), never a literal count (the user's caches direction 2026-09-11). Resolved ONCE
+    into a module slot at first use (the memory reader is defined below this class and read again at every snapshot
+    otherwise; round one, low 5). `mem_total` computes the fraction for a given reading (tests) and resolves nothing."""
+    if mem_total is not None:
+        return max(16, int(mem_total) // (64 * 1024 * 1024))
+    if _STAGE_RING_LEN[0] is None:
+        raw = os.environ.get("ROMP_PERF_STAGE_RING", "")
+        n = 0
+        try:
+            n = int(raw) if raw else 0
+        except ValueError:
+            n = 0
+        _STAGE_RING_LEN[0] = n if n > 0 else max(16, _mem_total_bytes() // (64 * 1024 * 1024))
+    return _STAGE_RING_LEN[0]
 
 
 class _PerfStats:
@@ -340,6 +354,7 @@ class _PerfStats:
             self.first_cycle = None
             self.stage_ring = None
             self._stage_mark = None
+            self._pusher_ident = None                 # the thread whose stages the split records: the pusher's, set at cycle_begin
             self.builds = {k: {"cached": 0, "built": 0, "ms": 0.0} for k in self.BUILDS}
             self.builds["chat"].update({"active_built": 0, "bg_built": 0, "moved": 0,
                                         "bg_miss": {k: 0 for k in self.CHAT_MISS}})   # see build_chat
@@ -418,7 +433,9 @@ class _PerfStats:
             if ms > p["cycle_ms_max"]:
                 p["cycle_ms_max"] = ms
             self.ring.append(ms)
-            split = {"s": round(dt, 3), "t": time.time(), "stages": self.cycle_stages}
+            split = {"s": round(dt, 3), "t": time.time(),
+                     "stages": {k: {"ms": round(v["ms"], 1), "bytes": v["bytes"], "hydrated": v["hydrated"]}
+                                for k, v in self.cycle_stages.items()}}
             if self.first_cycle is None:
                 self.first_cycle = split
             if self.stage_ring is None:
@@ -429,17 +446,28 @@ class _PerfStats:
 
     @staticmethod
     def _byte_marks():
-        """(the reader's bytes off disk, the assembly cut's hydrated bytes) so far: the two byte counters a stage moves."""
+        """(this THREAD's reader bytes off disk, this thread's hydrated bytes) so far: the two byte counters a stage moves,
+        per thread, so the pusher's split carries the pusher's own reads and not the judges' first pass or a boot warm
+        running through the same window (round one, low 2)."""
         try:
-            return em.read_bytes_total(), int(em.asm_checkpoint_stats().get("hydratedBytes") or 0)
+            return em.thread_read_bytes(), em.thread_hydrated_bytes()
         except Exception:
             return 0, 0
+
+    def _mine(self):
+        """Whether the calling thread is the one whose cycle the split records (the pusher's, set at cycle_begin): a
+        dashboard's connect push runs _push on the HTTP handler thread through the same stage calls, and its whole build
+        landed in the pusher cycle's split, in firstCycle and in the boot-health row, the boot being exactly when pages
+        redial (round one, medium). The cumulative totals take every thread's stages as before."""
+        return self._pusher_ident is not None and threading.get_ident() == self._pusher_ident
 
     def stage_boundary(self):
         """A stage boundary that closes no stage: the bytes read since the last boundary belong to the stage that closes
         next (the pusher's jobs before the push: `_push` marks its own start so its first sub-stage does not carry them)."""
         marks = self._byte_marks()
         with self.lock:
+            if not self._mine():
+                return
             prev = self._stage_mark
             self._stage_mark = marks
             if prev is not None:                            # the jobs before the push: to the cycle's `jobs` bucket
@@ -450,6 +478,8 @@ class _PerfStats:
         marks = self._byte_marks()
         with self.lock:
             self.stages[name] = self.stages.get(name, 0.0) + dt * 1000.0
+            if not self._mine():
+                return                                      # another thread's push: the totals alone
             cs = self.cycle_stages.setdefault(name, {"ms": 0.0, "bytes": 0, "hydrated": 0})
             cs["ms"] += dt * 1000.0
             if name == "push":                              # the container: its bytes are its sub-stages' (already attributed)
@@ -462,9 +492,12 @@ class _PerfStats:
                 self._stage_mark = marks
 
     def cycle_begin(self):
-        """The cycle's first byte mark: what the stages below it are measured from."""
+        """The cycle's opening, on the pusher's thread: the thread the split records, the split emptied (a push in the gap
+        between cycles, on any thread, lands in no cycle), and the first byte mark the stages are measured from."""
         marks = self._byte_marks()
         with self.lock:
+            self._pusher_ident = threading.get_ident()
+            self.cycle_stages = {}
             self._stage_mark = marks
 
     def first_cycle_split(self):
@@ -577,13 +610,17 @@ class _PerfStats:
         n = len(sorted_ms)
         return sorted_ms[min(n - 1, int(q * n))] if n else 0.0
 
-    def snapshot(self):
+    STAGE_RING_SERVED = 16   # the ring's floor: how many of the newest splits a plain GET /perf carries (`?ring=all` for the ring)
+
+    def snapshot(self, ring_all=False):
         with self.lock:
             ring = sorted(self.ring)
             pusher = dict(self.pusher)
             pusher["firstCycle"] = dict(self.first_cycle) if self.first_cycle is not None else None   # T397: the boot's
-            pusher["stageRing"] = list(self.stage_ring) if self.stage_ring is not None else []          #  first cycle's split
-            pusher["stageRingMax"] = self.stage_ring.maxlen if self.stage_ring is not None else _stage_ring_len()   # and the ring
+            sr = list(self.stage_ring) if self.stage_ring is not None else []                           #  first cycle's split
+            pusher["stageRing"] = sr if ring_all else sr[-self.STAGE_RING_SERVED:]   # the newest few by default: the whole ring
+            pusher["stageRingLen"] = len(sr)                                          #  is up to a few MB of JSON (round one, low 3)
+            pusher["stageRingMax"] = self.stage_ring.maxlen if self.stage_ring is not None else _stage_ring_len()
             stages = dict(self.stages)
             builds = {k: dict(v) for k, v in self.builds.items()}
             builds["chat"]["bg_miss"] = dict(self.builds["chat"]["bg_miss"])   # the nested map: a copy too
@@ -46470,6 +46507,8 @@ def _push(targets, connect=False, live_map=None):
     # The FLEET connects as its OWN app (the user 2026-06-29) so we build its per-session ledgers EVEN when no
     # chat client is open — previously the fleet rode app=feed and got ledgers only as a side effect of a chat
     # build (want_chat), so opening the fleet alone showed an empty/loading screen until a chat push happened.
+    _PERF_STATS.stage_boundary()                 # T397: the push's sub-stages measure their bytes from here (the cards-first
+    #                                              path below included: round one, low 1), not from the cycle's start
     want_fleet = any(c["app"] == "fleet" for c in targets)
     want_feed = _feed_audience(targets)          # the Sessions pane (app "fleet") rides the feed payload; chat needs feed["working"]
     want_tl = any(c["app"] == "timeline" for c in targets)
@@ -46502,7 +46541,6 @@ def _push(targets, connect=False, live_map=None):
         # The FEED's per-session Fleet ledger slice still rides along, attached AFTER the builds (want_chat —
         # we do NOT build all sessions just for a feed/fleet push: the user 2026-06-24 slow-load regression).
         chat_sessions = []
-        _PERF_STATS.stage_boundary()          # T397: the push's sub-stages measure their bytes from here, not from the cycle's start
         _t_stage = time.monotonic()                      # /perf stage clock: chat, then feed, then timeline
         if want_chat or want_fleet:   # the fleet needs every session's ledger slice (built below, attached to feed)
             # TABS-FIRST (the user 2026-06-26): ship name+color per tab so the client can paint the WHOLE strip
@@ -56237,7 +56275,8 @@ class Handler(BaseHTTPRequestHandler):
                     rows = rows + _thread_rows()               # bus (the user 2026-08-22); every existing
                 return self._send(200, json.dumps(rows), "application/json", cache="no-cache")   # consumer unchanged
             if p == "/perf":                                  # the kernel's performance counters (`romp perf`); shape: _PerfStats
-                return self._send(200, json.dumps(_PERF_STATS.snapshot()), "application/json", cache="no-cache")
+                return self._send(200, json.dumps(_PERF_STATS.snapshot(ring_all=(q.get("ring") or [""])[0] == "all")),
+                                  "application/json", cache="no-cache")   # ?ring=all: the whole stage ring (T397)
             if p == "/commands":                              # slash-command list for the composer's "/" autocomplete (SDK get_server_info, per-cwd cached)
                 sid = (q.get("sid") or [""])[0]
                 cmds, warming = _commands_for_cwd(_cwd_of(sid) if sid else "")

--- a/tests/test_first_cycle_stage_split.py
+++ b/tests/test_first_cycle_stage_split.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""T397 (2026-09-12): a boot's first pusher cycle took 59 s against 25 to 33 s all day, and /perf kept only cumulative stage
+totals and a ring of whole-cycle durations, so nothing named the stage. The pusher keeps each cycle's stage split (wall, the
+reader's bytes, the hydrated bytes), the boot's first for the process under `pusher.firstCycle`, the last cycles in a ring
+sized as a fraction of memory under `pusher.stageRing`, and the restart ledger's boot-health row carries the first split."""
+import os
+import sys
+import time
+import unittest
+HERE = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, HERE)
+from test_asm_checkpoint import em, kernel_module   # noqa: E402
+
+
+class StageSplitUnit(unittest.TestCase):
+    def setUp(self):
+        self.km = kernel_module()
+
+    def test_the_ring_is_a_fraction_of_memory_never_a_literal(self):
+        km = self.km
+        self.assertEqual(km._stage_ring_len(64 * 1024 ** 3), 1024, "one cycle per 64 MiB: a 64 GB box keeps 1024")
+        self.assertEqual(km._stage_ring_len(4 * 1024 ** 3), 64)
+        self.assertEqual(km._stage_ring_len(512 * 1024 ** 2), 16, "the floor")
+        self.assertEqual(km._stage_ring_len(0), 16)
+        self.assertGreaterEqual(km._stage_ring_len(), 16, "the machine's reading")
+
+    def test_the_first_cycle_is_kept_and_every_cycle_rides_the_ring(self):
+        km = self.km
+        ps = km._PerfStats()
+        ps.cycle_begin()
+        ps.stage("push.chat", 0.010); ps.stage("push", 0.010); ps.stage("jobs", 0.005)
+        ps.cycle(0.020)
+        ps.cycle_begin()
+        ps.stage("jobs", 0.001)
+        ps.cycle(0.002)
+        snap = ps.snapshot()["pusher"]
+        first = snap["firstCycle"]
+        self.assertEqual(first["s"], 0.02)
+        self.assertEqual(sorted(first["stages"]), ["jobs", "push", "push.chat"])
+        self.assertAlmostEqual(first["stages"]["push.chat"]["ms"], 10.0)
+        self.assertEqual(set(first["stages"]["jobs"]), {"ms", "bytes", "hydrated"})
+        self.assertEqual(len(snap["stageRing"]), 2, "both cycles in the ring")
+        self.assertEqual(snap["stageRing"][1]["stages"], {"jobs": {"ms": 1.0, "bytes": 0, "hydrated": 0}})
+        self.assertEqual(snap["stageRingMax"], km._stage_ring_len())
+        self.assertIsNone(km._PerfStats().snapshot()["pusher"]["firstCycle"], "no cycle yet: no split")
+
+    def test_a_stages_bytes_are_the_readers_bytes_since_the_previous_boundary(self):
+        km = self.km
+        ps = km._PerfStats()
+        ps.cycle_begin()
+        em._count_read("/lab/a.jsonl", 1000)                 # a read during the jobs before the push
+        ps.stage_boundary()                                  # the push begins: those bytes are the jobs'
+        em._count_read("/lab/b.jsonl", 250)                  # a read during the chat build
+        ps.stage("push.chat", 0.001)
+        ps.stage("push", 0.001)
+        em._count_read("/lab/c.jsonl", 50)                   # a read during the jobs after the push
+        ps.stage("jobs", 0.001)
+        ps.cycle(0.003)
+        st = ps.snapshot()["pusher"]["firstCycle"]["stages"]
+        self.assertEqual(st["push.chat"]["bytes"], 250)
+        self.assertEqual(st["push"]["bytes"], 250, "the container carries its sub-stages' bytes")
+        self.assertEqual(st["jobs"]["bytes"], 1050, "the jobs before and after the push")
+
+
+class LabBootFirstCycle(unittest.TestCase):
+    """A lab boot whose first cycle runs at least two stages: the real pusher cycle with every tick job a no-op and the push a
+    short sleep, over a hermetic kernel module; the split names both stages, and the boot-health row carries it."""
+    JOBS = ("_judge_tick", "_nudge_tick", "_reconcile_tick")
+
+    def setUp(self):
+        self.km = km = kernel_module()
+        self.saved = (km.NAMES, km._live_map, km._push_all, km._append_restart_cut, km._BOOT_HEALTH_DONE[0])
+        km.NAMES = {}
+        km._live_map = lambda: {}
+        self.rows = []
+        km._append_restart_cut = lambda row: self.rows.append(row)
+        km._BOOT_HEALTH_DONE[0] = False
+        km._PERF_STATS.reset()
+
+    def tearDown(self):
+        km = self.km
+        km.NAMES, km._live_map, km._push_all, km._append_restart_cut, km._BOOT_HEALTH_DONE[0] = self.saved
+        km._PERF_STATS.reset()
+
+    def test_the_boots_first_cycle_names_its_stages(self):
+        km = self.km
+        km._push_all = lambda live_map=None: time.sleep(0.005)
+        t0 = time.monotonic()
+        km._pusher_cycle_jobs(int(time.time()), {}, True)
+        dt = time.monotonic() - t0
+        km._PERF_STATS.cycle(dt)
+        km._boot_health_first_cycle(dt)
+        snap = km._PERF_STATS.snapshot()["pusher"]
+        first = snap["firstCycle"]
+        self.assertIsNotNone(first, "the first cycle's split is kept")
+        self.assertTrue({"jobs", "push"} <= set(first["stages"]), "both stages named: %r" % sorted(first["stages"]))
+        self.assertGreaterEqual(first["stages"]["push"]["ms"], 5.0)
+        self.assertLessEqual(sum(v["ms"] for k, v in first["stages"].items() if k in ("jobs", "push")), first["s"] * 1000.0 + 5.0,
+                             "the stages fit the cycle's wall")
+        self.assertEqual(len(self.rows), 1, "one boot-health row")
+        self.assertEqual(sorted(self.rows[0]["stages"]), sorted(first["stages"]), "the row carries the split")
+        self.assertEqual(self.rows[0]["firstCycleS"], round(dt, 2))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_first_cycle_stage_split.py
+++ b/tests/test_first_cycle_stage_split.py
@@ -3,10 +3,13 @@
 totals and a ring of whole-cycle durations, so nothing named the stage. The pusher keeps each cycle's stage split (wall, the
 reader's bytes, the hydrated bytes), the boot's first for the process under `pusher.firstCycle`, the last cycles in a ring
 sized as a fraction of memory under `pusher.stageRing`, and the restart ledger's boot-health row carries the first split."""
+import inspect
 import os
 import sys
+import threading
 import time
 import unittest
+from unittest import mock
 HERE = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, HERE)
 from test_asm_checkpoint import em, kernel_module   # noqa: E402
@@ -23,6 +26,17 @@ class StageSplitUnit(unittest.TestCase):
         self.assertEqual(km._stage_ring_len(512 * 1024 ** 2), 16, "the floor")
         self.assertEqual(km._stage_ring_len(0), 16)
         self.assertGreaterEqual(km._stage_ring_len(), 16, "the machine's reading")
+        # round one, low 5: resolved ONCE into a module slot, with an override
+        saved = km._STAGE_RING_LEN[0]
+        self.addCleanup(lambda: km._STAGE_RING_LEN.__setitem__(0, saved))
+        km._STAGE_RING_LEN[0] = None
+        with mock.patch.dict(os.environ, {"ROMP_PERF_STAGE_RING": "40"}):
+            self.assertEqual(km._stage_ring_len(), 40, "the override names the length")
+        with mock.patch.dict(os.environ, {"ROMP_PERF_STAGE_RING": "9000"}):
+            self.assertEqual(km._stage_ring_len(), 40, "resolved once: a later environment does not move it")
+        km._STAGE_RING_LEN[0] = None
+        with mock.patch.dict(os.environ, {"ROMP_PERF_STAGE_RING": "nonsense"}):
+            self.assertGreaterEqual(km._stage_ring_len(), 16, "a bad override falls to the memory fraction")
 
     def test_the_first_cycle_is_kept_and_every_cycle_rides_the_ring(self):
         km = self.km
@@ -42,6 +56,7 @@ class StageSplitUnit(unittest.TestCase):
         self.assertEqual(len(snap["stageRing"]), 2, "both cycles in the ring")
         self.assertEqual(snap["stageRing"][1]["stages"], {"jobs": {"ms": 1.0, "bytes": 0, "hydrated": 0}})
         self.assertEqual(snap["stageRingMax"], km._stage_ring_len())
+        self.assertEqual(snap["stageRingLen"], 2)
         self.assertIsNone(km._PerfStats().snapshot()["pusher"]["firstCycle"], "no cycle yet: no split")
 
     def test_a_stages_bytes_are_the_readers_bytes_since_the_previous_boundary(self):
@@ -60,6 +75,69 @@ class StageSplitUnit(unittest.TestCase):
         self.assertEqual(st["push.chat"]["bytes"], 250)
         self.assertEqual(st["push"]["bytes"], 250, "the container carries its sub-stages' bytes")
         self.assertEqual(st["jobs"]["bytes"], 1050, "the jobs before and after the push")
+
+    def test_the_split_is_the_pusher_threads_alone(self):
+        """Round one, medium: a dashboard's connect push runs _push on the HTTP handler thread through the same stage calls; its
+        whole build landed in the pusher cycle's split (a 5 ms cycle reporting a 20 s push.chat), in firstCycle and in the
+        boot-health row. The split records the thread that opened the cycle alone; the cumulative totals take every thread."""
+        km = self.km
+        ps = km._PerfStats()
+        ps.cycle_begin()
+        ps.stage("push.chat", 0.005); ps.stage("push", 0.005)
+        def connect_push():
+            ps.stage_boundary(); ps.stage("push.chat", 20.0); ps.stage("push", 20.0)
+        th = threading.Thread(target=connect_push); th.start(); th.join()
+        ps.stage("jobs", 0.001)
+        ps.cycle(0.006)
+        first = ps.snapshot()["pusher"]["firstCycle"]
+        self.assertEqual(first["stages"]["push.chat"]["ms"], 5.0, "the pusher's own push.chat, not the connect's 20 s")
+        self.assertLessEqual(sum(v["ms"] for k, v in first["stages"].items() if k in ("jobs", "push")), first["s"] * 1000.0 + 0.5,
+                             "the stages fit the cycle's wall with a second thread pushing mid-cycle")
+        self.assertAlmostEqual(ps.snapshot()["stages_ms"]["push.chat"], 20005.0, "the totals took both")
+
+    def test_a_push_in_the_gap_between_cycles_lands_in_no_cycle(self):
+        """A connect push between two cycles (on any thread) is not the next cycle's: cycle_begin empties the split."""
+        km = self.km
+        ps = km._PerfStats()
+        ps.cycle_begin(); ps.stage("jobs", 0.001); ps.cycle(0.002)
+        ps.stage("push.chat", 9.0); ps.stage("push", 9.0)      # in the gap, on the pusher's own thread even
+        ps.cycle_begin(); ps.stage("jobs", 0.002); ps.cycle(0.002)
+        ring = ps.snapshot()["pusher"]["stageRing"]
+        self.assertEqual(sorted(ring[1]["stages"]), ["jobs"], "the gap's push is in no cycle: %r" % ring[1])
+
+    def test_a_stages_bytes_are_the_pusher_threads_own(self):
+        """Round one, low 2: another thread's reads in the window (the judges' first pass, a boot warm) are not the pusher's."""
+        km = self.km
+        ps = km._PerfStats()
+        ps.cycle_begin(); ps.stage_boundary()
+        def other_reader():
+            em._count_read("/lab/judge.jsonl", 5000)
+        th = threading.Thread(target=other_reader); th.start(); th.join()
+        em._count_read("/lab/mine.jsonl", 70)
+        ps.stage("push.chat", 0.001); ps.stage("push", 0.001); ps.stage("jobs", 0.001); ps.cycle(0.003)
+        st = ps.snapshot()["pusher"]["firstCycle"]["stages"]
+        self.assertEqual(st["push.chat"]["bytes"], 70, "the pusher thread's own read alone: %r" % st)
+
+    def test_the_boundary_sits_at_the_pushs_entry_before_the_cards_first_path(self):
+        """Round one, low 1: on the boot's first cycle the cards-first feed closed push.feedFirst before the boundary, absorbing
+        the pre-push jobs' bytes; the boundary is the first thing _push does."""
+        src = inspect.getsource(self.km._push)
+        self.assertLess(src.index("_PERF_STATS.stage_boundary()"), src.index("_feed_first(now, live_map, targets, connect)"))
+        self.assertEqual(src.count("_PERF_STATS.stage_boundary()"), 1)
+
+    def test_a_plain_snapshot_carries_the_newest_splits_and_the_ring_on_request(self):
+        """Round one, low 3: the whole ring is up to a few MB of JSON on every GET /perf; a plain snapshot carries the newest
+        16 (the ring's floor) and the ring's length, `ring_all` the whole ring, and ms rounded to one decimal."""
+        km = self.km
+        ps = km._PerfStats()
+        for i in range(20):
+            ps.cycle_begin(); ps.stage("jobs", 0.0012345); ps.cycle(0.002)
+        plain = ps.snapshot()["pusher"]; whole = ps.snapshot(ring_all=True)["pusher"]
+        self.assertEqual(len(plain["stageRing"]), km._PerfStats.STAGE_RING_SERVED)
+        self.assertEqual((plain["stageRingLen"], len(whole["stageRing"])), (20, 20))
+        self.assertEqual(plain["stageRing"][-1]["stages"]["jobs"]["ms"], 1.2, "one decimal")
+        src = inspect.getsource(km)
+        self.assertIn('_PERF_STATS.snapshot(ring_all=(q.get("ring") or [""])[0] == "all")', src, "GET /perf?ring=all serves the ring")
 
 
 class LabBootFirstCycle(unittest.TestCase):


### PR DESCRIPTION
Tier: feature (a self-contained new diagnostic inside the existing perf model: a new pusher block field and a new field on the boot-health ledger row; nothing it reports existed before). Re-tier if you read it as a fix to the boot-health row.

**Why:** the boot after the rewound memo deployed took 58.97 s for its first pusher cycle against 25 to 33 s at the day's five other boots, and `/perf` kept only cumulative stage totals (`stages_ms`) and a ring of whole-cycle durations, so nothing named the stage that jumped and the read had to say "not attributable without the split".

**What:** `_PerfStats` keeps a per-cycle stage split. Each stage's close records its wall `ms`, the reader's `bytes` off disk and the assembly cut's `hydrated` bytes since the previous stage boundary (a new one-integer running total in the event model, `read_bytes_total`; the `push` container carries its sub-stages' sums; the jobs before the push land in `jobs` through a boundary mark at the push's start). `cycle()` closes the split: the boot's first is kept for the process as `pusher.firstCycle`, and every cycle's rides `pusher.stageRing`, a deque whose length is one entry per 64 MiB of the machine's memory floored at 16 (`stageRingMax`; a 64 GB box keeps 1024 cycles, a 4 GB one 64), never a literal count. The restart ledger's boot-health row carries the first cycle's `stages` beside `firstCycleS`, so a slow boot names its stage without the kernel alive. The reference describes the fields.

**Tests** (`tests/test_first_cycle_stage_split.py`): the ring length as a function of memory with its floor; the first cycle kept and every cycle in the ring, with an empty snapshot before any cycle; a stage's bytes as the reader's bytes since the previous boundary (the jobs before and after the push, the chat build's own, the container's sum); and a lab first cycle, the real `_pusher_cycle_jobs` with every tick job a no-op and the push a short sleep over a hermetic kernel module, whose split names both `jobs` and `push`, fits the cycle's wall, and rides the boot-health row. All four fail at the base by absence.

**Measurement on the next deploy boot:** `pusher.firstCycle.stages` beside `firstCycleS` in the boot read, so the next 59 s names its stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)