### PR TITLE
The lazy planner's review lows: a named tool call frames a unit, an empty late read retires it, one text rule for the workless follow-up, the planner stubs take the keyword and the nudge gate counts its except leg, the caller pin and the whole-unit comparison (T396 follow-up)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1709,8 +1709,9 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   with `entries`, `bytes` and `off`); `chain` is the write-moment chain memo
   (`hit`, `miss`, `populate`, `bypass`); `nudgeGate` is the auto-nudge walk's
   planner-placement gate, derived once per (parse, store) and served while
-  both stand (`served`, `derived`; a healthy quiet box serves almost every
-  cycle); `cleared` is the feed's clear set, parsed once per state of
+  both stand (`served`, `derived`, and `failed`: the derivations that raised
+  and waved nothing through, zero on a healthy box; a healthy quiet box serves
+  almost every cycle); `cleared` is the feed's clear set, parsed once per state of
   `cleared.jsonl` (its stat, taken before the read) and served while the file
   stands (`served`, `derived`); `courierSkip` is the courier's change gate
   (`skipped`, `scanned`, `recorded`: a session whose parse, store, journal,

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -11289,8 +11289,9 @@ def _plan_session(fsid, path, now):
                 # A unit the lazy gate yielded whose text reads empty (a shape the scalars cannot see: an assistant message
                 # whose content is a bare string; a blind spot of any later kind): RETIRE it, never skip it. Skipped, it
                 # wrote no placement and no retirement, and the nudge placement gate read its key as unplanned on every
-                # tick and silenced the session's escalation ladder (the 2026-08-16 wedge shape; round three, low 1).
-                store["placements"][key] = None
+                # tick and silenced the session's escalation ladder (the 2026-08-16 wedge shape; round three, low 1). The
+                # unit's OWN key: `key` here is the collection loop's last binding, not this unit's (round four, medium).
+                store["placements"][_unit_key(seg_id, phase)] = None
                 save_goals(fsid, store)
                 continue
             if vq is None:

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2667,8 +2667,9 @@ def _unit_nonempty(atoms):
     nothing (the one case a scalar cannot see). The planner's emptiness gate asks this in place of reading the unit text,
     which hydrated every assistant body of every unplaced segment at every pass (42.8 MB on one boot)."""
     for a in atoms:
-        if a.get("type") == "assistant" and not a.get("isApiError") and (em._has_text(a) or em.atom_tool_uses(a)):
-            return True
+        if a.get("type") == "assistant" and not a.get("isApiError") \
+                and (em._has_text(a) or any(nm for _i, nm in em.atom_tool_uses(a))):   # a tool call counts with a NAME, as
+            return True                                                                  #  _unit_text frames it (round three, low 1)
     return any(_FOLLOWUP_MARKER_RE.sub("", _atom_text(a)).strip()
                for a in atoms if a.get("type") == "user" and a.get("author") is not None and em._has_text(a))
 
@@ -9270,8 +9271,9 @@ def plan_units(session, store=None, floor=_UNSET_FLOOR, lazy_text=False):
                     # own reopen/dismiss row is the release, and _strip_unevidenced_dones keeps a
                     # workless reply from CLAIMING completion (the closer holds done authority). Nudges
                     # keep their skip: their machinery re-asks and escalates on its own.
-                    _put("work", _wt, _seg_human(seg), _seg_followup(seg))
-                continue
+                    _wn = _work_note(seg)                 # ONE text rule with the ended work-run below and with unit_text_for
+                    _put("work", (lambda: (_wn + _wt()) if _wt() else "") if _wn else _wt, _seg_human(seg), _seg_followup(seg))
+                continue                                  #  (round three, low 2: the lazy road resolves through unit_text_for)
             _pm = _seg_peer(seg)
             if _pm and _pm[0]:                            # POSTAL segment with a KNOWN sender → DELEGATION work-run
                 if not is_open_final:                     # ended → the recipient's work is known; place it under G
@@ -11284,6 +11286,12 @@ def _plan_session(fsid, path, now):
                 continue
             text = unit_text_for(seg, phase)
             if not text:
+                # A unit the lazy gate yielded whose text reads empty (a shape the scalars cannot see: an assistant message
+                # whose content is a bare string; a blind spot of any later kind): RETIRE it, never skip it. Skipped, it
+                # wrote no placement and no retirement, and the nudge placement gate read its key as unplanned on every
+                # tick and silenced the session's escalation ladder (the 2026-08-16 wedge shape; round three, low 1).
+                store["placements"][key] = None
+                save_goals(fsid, store)
                 continue
             if vq is None:
                 vq = _mint_quote(seg)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -12763,7 +12763,8 @@ def _nudge_response_ready(turns, store, rec, gid, now):
 
 
 _nudge_gate_memo = {}            # sid -> (parse key, the shared view object, clears-log stat, unplanned): the gate's answer while its inputs stand
-_NUDGE_GATE_STATS = {"served": 0, "derived": 0}   # /perf memos.nudgeGate: how often the walk re-derived the gate
+_NUDGE_GATE_STATS = {"served": 0, "derived": 0, "failed": 0}   # /perf memos.nudgeGate: how often the walk re-derived the gate,
+#                                                                  and how often the derivation raised (the except leg: waves nothing through)
 _NUDGE_GATE_MEMO_MAX = 512
 
 
@@ -12799,6 +12800,7 @@ def _nudge_placement_gate(sid, turns, store):
                         for u in jd.plan_units({"turns": turns}, store, lazy_text=True))   # keys alone (T396)
     except Exception:
         unplanned = False                        # minimal/legacy turn shapes → the closer gate stands alone,
+        _NUDGE_GATE_STATS["failed"] += 1         # counted, so a test can pin that this leg was never entered
         sys.stderr.write("auto-nudge placement gate (session %s): %s\n"   # but never SILENTLY (the user
                          % (sid, traceback.format_exc()))                 #  2026-07-21: a mute gate error
         return unplanned                         #  would wave nudges through); a failed derivation is not cached

--- a/tests/test_nudge_bundle.py
+++ b/tests/test_nudge_bundle.py
@@ -276,7 +276,7 @@ class AutoNudgeBundlesSameTick(unittest.TestCase):
         km._revivers_pending = lambda *a: None
         km._pending_ops = {}
         jd._segs = lambda tn, store: []
-        jd.plan_units = lambda session, store: []
+        jd.plan_units = lambda session, store, **kw: []   # the callers pass lazy_text (T396)
         self.turns = [{"id": "t1", "t": T0, "end": T0 + 10, "ended": True, "atoms": [{}, {}, {}]}]
         jd.parsed_session = lambda sid, paths, now: {"turns": self.turns}
         self.store = _store({G1: _node(G1, "Ship the auth refactor"),

--- a/tests/test_nudge_fresh_guard.py
+++ b/tests/test_nudge_fresh_guard.py
@@ -77,7 +77,7 @@ class FreshGuard(unittest.TestCase):
         km._all_outstanding_delegated = lambda nodes, gid: False
         km._pending_ops = {}
         jd._segs = lambda tn, store: []
-        jd.plan_units = lambda session, store: []
+        jd.plan_units = lambda session, store, **kw: []   # the callers pass lazy_text (T396)
         uid = "u-t1"
         self.turns = [{"id": "t1", "t": ARM_T, "end": ARM_T + 60, "ended": True,
                        "trigger": {"uuid": uid},

--- a/tests/test_nudge_gate_memo.py
+++ b/tests/test_nudge_gate_memo.py
@@ -120,7 +120,7 @@ class GateMemo(_Gate):
             c = km._nudge_placement_gate(SID, self._turns(), self._view())   # the same cached parse and view
         self.assertEqual((a, b, c), (True, True, True), "an unplaced ended segment: the planner queue is not empty")
         self.assertEqual(pu.call_count, 1, "derived once; the two later calls were served")
-        self.assertEqual(km._NUDGE_GATE_STATS, {"served": 2, "derived": 1})
+        self.assertEqual(km._NUDGE_GATE_STATS, {"served": 2, "derived": 1, "failed": 0})
 
     def test_the_answer_is_the_direct_derivation_before_and_after_the_placement_lands(self):
         turns, store = self._turns(), self._view()
@@ -186,7 +186,7 @@ class GateMemo(_Gate):
             got = km._nudge_placement_gate(SID, self._turns(), view_new)
         self.assertEqual(pu.call_count, 1, "re-derived against the current view")
         self.assertFalse(got, "the placement landed: the queue is empty")
-        self.assertEqual(km._NUDGE_GATE_STATS, {"served": 0, "derived": 2})
+        self.assertEqual(km._NUDGE_GATE_STATS, {"served": 0, "derived": 2, "failed": 0})
         self.assertIs(km._nudge_gate_memo[SID][1], view_new)
 
     def test_a_store_that_is_not_the_shared_view_is_derived_every_time(self):
@@ -235,7 +235,7 @@ class GateMemo(_Gate):
         km._nudge_placement_gate(SID, self._turns(), self._view())
         km._nudge_placement_gate(SID, self._turns(), self._view())
         snap = km._PERF_STATS.snapshot()
-        self.assertEqual(snap["memos"]["nudgeGate"], {"served": 1, "derived": 1})
+        self.assertEqual(snap["memos"]["nudgeGate"], {"served": 1, "derived": 1, "failed": 0})
 
 
     def test_served_by_the_turns_held_when_an_agent_view_is_the_newest_slot(self):
@@ -255,7 +255,7 @@ class GateMemo(_Gate):
         with patch.object(jd, "plan_units", wraps=jd.plan_units) as pu:
             km._nudge_placement_gate(SID, turns, store)
         self.assertEqual(pu.call_count, 0, "served from the memo: the entry is found by the turns held, not the newest slot")
-        self.assertEqual(km._NUDGE_GATE_STATS, {"served": 1, "derived": 1})
+        self.assertEqual(km._NUDGE_GATE_STATS, {"served": 1, "derived": 1, "failed": 0})
 
 
 class WalkReadsTheSharedView(_Gate):

--- a/tests/test_nudge_injected_turn_arm.py
+++ b/tests/test_nudge_injected_turn_arm.py
@@ -156,7 +156,7 @@ class InjectedTurnDeadlockEndToEnd(unittest.TestCase):
         km._revivers_pending = lambda *a: ""          # every other reviver exhausted
         km._pending_ops = {}
         jd._segs = lambda tn, store: []
-        jd.plan_units = lambda session, store: []
+        jd.plan_units = lambda session, store, **kw: []   # the callers pass lazy_text (T396)
         # _turn_romp_injected stays REAL: the deadlock lives in its interaction with the arm scan.
         self.turns = [self._turn("t1", ARM_T, "human", ended=True),
                       self._turn("t2", INJ_T, "romp", ended=True)]

--- a/tests/test_nudge_memo_deadlock.py
+++ b/tests/test_nudge_memo_deadlock.py
@@ -75,7 +75,7 @@ class MemoDeadlock(unittest.TestCase):
         km._all_outstanding_delegated = lambda nodes, gid: False
         km._pending_ops = {}
         jd._segs = lambda tn, store: []
-        jd.plan_units = lambda session, store: []
+        jd.plan_units = lambda session, store, **kw: []   # the callers pass lazy_text (T396)
         uid = "u-t1"
         self.turns = [{"id": "t1", "t": ARM_T, "end": ARM_T + 60, "ended": True,
                        "trigger": {"uuid": uid},

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -160,7 +160,7 @@ class Collector(unittest.TestCase):
         self.assertEqual(set(snap["memos"]["goalArchive"]), {"served", "loaded"})
         self.assertEqual(set(snap["memos"]["backref"]), {"served", "built"},
                          "the sender-board walk behind the courier link repair: built once per input state (2026-09-09)")
-        self.assertEqual(snap["memos"]["nudgeGate"], {"served": 0, "derived": 0},
+        self.assertEqual(snap["memos"]["nudgeGate"], {"served": 0, "derived": 0, "failed": 0},
                          "the nudge walk's placement gate: served vs re-derived (2026-09-09)")
         self.assertEqual(set(snap["memos"]["cleared"]), {"served", "derived"},
                          "the clear set: parsed once per file state, served while it stands (2026-09-09)")

--- a/tests/test_planner_lazy_unit_text.py
+++ b/tests/test_planner_lazy_unit_text.py
@@ -75,12 +75,87 @@ class LazyUnitText(Harness):
             self.assertEqual(jd.unit_text_for(seg, lu[1]), eu[3], "the consumer's late read equals the eager text")
 
     def test_the_production_callers_take_the_units_lazily(self):
+        """All three call sites, by source: the plan pass (its migration pre-pass and its loop), the fast-forward on unmute,
+        and the kernel's nudge placement gate (round three, low 4: the pin missed the fast-forward and rode a hasattr)."""
         km = kernel_module(); jd = km.jd
         src = inspect.getsource(jd._plan_session)
         self.assertEqual(src.count("plan_units(session, store, floor=floor, lazy_text=True)"), 2, "the migration pre-pass and the plan loop")
         self.assertIn("if text is None:", src, "the consumer reads the text after its filters (T377's road)")
-        self.assertIn("lazy_text=True", inspect.getsource(km._auto_nudge_unplanned) if hasattr(km, "_auto_nudge_unplanned") else
-                      open(km.__file__).read().split('jd.plan_units({"turns": turns}, store')[1][:40], "the nudge gate reads keys alone")
+        self.assertIn("plan_units(session, store, lazy_text=True)", inspect.getsource(jd.fast_forward_placements), "the fast-forward reads keys alone")
+        self.assertIn('jd.plan_units({"turns": turns}, store, lazy_text=True)', inspect.getsource(km._nudge_placement_gate), "the nudge gate reads keys alone")
+
+    def test_lazy_units_resolve_to_the_eager_units_in_every_field_over_every_golden_scenario(self):
+        """The whole-unit comparison: over every golden scenario, whole and restored, the lazy units equal the eager ones in
+        every field once the lazy text and quote are resolved as the plan pass resolves them (unit_text_for, _mint_quote)."""
+        jd = kernel_module().jd
+        store = {"rompUuid": SID, "seq": 0, "nodes": {}, "placements": {}, "status": {}, "placementsV": jd.PLACEMENTS_V}
+        n = 0
+        for name in G.SINGLE_FILE:
+            records, sent = G.SINGLE_FILE[name]
+            path = self.write("units-" + name, records(), sent=sent)
+            for shape in ("whole", "restored"):
+                self.fresh()
+                if shape == "whole":
+                    em._CKPT_DIR_FN = None
+                    try:
+                        tree = self.parse(path)
+                    finally:
+                        em.set_checkpoint_dir(lambda: self.ck)
+                else:
+                    self.parse(path); self.doc(path); self.fresh(); tree = self.parse(path)
+                segs = {seg["id"]: seg for seg in _segments(tree)}
+                eager = jd.plan_units(tree, store)
+                lazy = jd.plan_units(tree, store, lazy_text=True)
+                self.assertEqual(len(lazy), len(eager), "%s/%s" % (name, shape))
+                for lu, eu in zip(lazy, eager):
+                    with self.subTest(scenario=name, shape=shape, unit=(lu[0], lu[1])):
+                        seg = segs[lu[0]]
+                        text = lu[3] if lu[3] is not None else jd.unit_text_for(seg, lu[1])
+                        quote = lu[7] if lu[7] is not None else jd._mint_quote(seg)
+                        self.assertEqual((lu[0], lu[1], lu[2], text, lu[4], lu[5], lu[6], quote), tuple(eu))
+                        n += 1
+        self.assertGreater(n, 40, "units compared: %d" % n)
+
+    def test_the_gates_blind_spots_and_the_consumers_retire(self):
+        """Round three, low 1: a tool call without a name is not a unit (as _unit_text frames it); an assistant message whose
+        content is a bare string is a blind spot the scalars cannot see (nt is computed from the normalized content), so the
+        gate says non-empty while the text reads empty, and the plan pass RETIRES such a unit instead of skipping it, so the
+        nudge placement gate never reads its key as unplanned forever."""
+        km = kernel_module(); jd = km.jd
+        nameless = {"type": "assistant", "uuid": "a", "t": 2.0, "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "t1", "name": "", "input": {}}]}}
+        self.assertFalse(jd._unit_nonempty([nameless]), "a nameless tool call is not framed")
+        self.assertEqual(jd._unit_text([nameless]), "")
+        bare = {"type": "assistant", "uuid": "a", "t": 2.0, "message": {"role": "assistant", "content": "a bare string the CLI never writes"}}
+        self.assertTrue(jd._unit_nonempty([bare]), "the blind spot: the scalar sees text")
+        self.assertEqual(jd._unit_text([bare]), "", "the framing sees no block")
+        src = inspect.getsource(jd._plan_session)
+        i = src.index("text = unit_text_for(seg, phase)")
+        tail = src[i:i + 900]
+        self.assertIn("if not text:", tail)
+        self.assertIn('store["placements"][key] = None', tail, "an empty late read retires the unit")
+        self.assertLess(tail.index('store["placements"][key] = None'), tail.index("continue"), "retired before the continue")
+
+    def test_the_nudge_gates_except_leg_is_counted_and_not_entered_by_a_widened_stub(self):
+        """Round three, low 3: six test modules stubbed plan_units without the keyword; the gate's except swallowed the TypeError
+        into a stderr trace and answered not unplanned, and those modules stayed green by accident. The leg is counted now
+        (memos.nudgeGate.failed), a widened stub never enters it, and a narrow one does."""
+        km = kernel_module(); jd = km.jd
+        saved = jd.plan_units
+        self.addCleanup(setattr, jd, "plan_units", saved)
+        km._NUDGE_GATE_STATS["failed"] = 0
+        turns = [{"id": "t1", "t": 1.0, "end": 2.0, "ended": True, "atoms": [], "trigger": None}]
+        jd.plan_units = lambda session, store, **kw: []
+        km._nudge_placement_gate(SID, turns, {"placements": {}})
+        self.assertEqual(km._NUDGE_GATE_STATS["failed"], 0, "a widened stub: the leg not entered")
+        jd.plan_units = lambda session, store: []
+        import io
+        err = io.StringIO(); saved_err = sys.stderr; sys.stderr = err
+        try:
+            self.assertFalse(km._nudge_placement_gate(SID, turns, {"placements": {}}))
+        finally:
+            sys.stderr = saved_err
+        self.assertEqual(km._NUDGE_GATE_STATS["failed"], 1, "a narrow stub: the leg entered and counted")
+        self.assertIn("lazy_text", err.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/test_planner_lazy_unit_text.py
+++ b/tests/test_planner_lazy_unit_text.py
@@ -5,9 +5,13 @@ one boot through _unit_text<-_seam_text). The production callers now take the un
 the markers' scalars and the user bodies (_unit_nonempty), the text and the quote are read by _plan_session after its filters,
 through the placed-yield road T377 built. Synthetic transcripts only (the golden builders)."""
 import inspect
+import json
 import os
+import shutil
+import tempfile
 import sys
 import unittest
+from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, HERE)
 from test_asm_checkpoint import em, G, SID, NOW, Harness, kernel_module   # noqa: E402
@@ -128,12 +132,53 @@ class LazyUnitText(Harness):
         bare = {"type": "assistant", "uuid": "a", "t": 2.0, "message": {"role": "assistant", "content": "a bare string the CLI never writes"}}
         self.assertTrue(jd._unit_nonempty([bare]), "the blind spot: the scalar sees text")
         self.assertEqual(jd._unit_text([bare]), "", "the framing sees no block")
-        src = inspect.getsource(jd._plan_session)
-        i = src.index("text = unit_text_for(seg, phase)")
-        tail = src[i:i + 900]
-        self.assertIn("if not text:", tail)
-        self.assertIn('store["placements"][key] = None', tail, "an empty late read retires the unit")
-        self.assertLess(tail.index('store["placements"][key] = None'), tail.index("continue"), "retired before the continue")
+        self.assertIn("if not text:", inspect.getsource(jd._plan_session))
+
+    def test_an_empty_late_read_retires_that_units_own_key_and_the_next_unit_still_plans(self):
+        """Round four, medium: the retire wrote the collection loop's last-bound `key`, so a phantom unit's empty late read retired
+        some OTHER unit (the next prompt's) and left the phantom's key absent: the prompt never planned and the nudge gate read
+        the phantom as unplanned. Driven through the real _plan_session: plan_units stubbed to yield a phantom work unit (its
+        late text empty) then a real human prompt unit; the phantom's own key is the one retired, the prompt plans."""
+        km = kernel_module(); jd = km.jd
+        fsid = "7a396000-2222-4333-8444-000000000396"
+        td = Path(tempfile.mkdtemp()); (td / "state").mkdir()
+        saved_state = jd.STATE; jd._rebind_state(td / "state")
+        saved = (jd.plan_units, jd.unit_text_for, jd.opener_llm, jd._SDK_OWNER_FN)
+        def restore():
+            jd.plan_units, jd.unit_text_for, jd.opener_llm, jd._SDK_OWNER_FN = saved
+            jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear(); jd._rebind_state(saved_state); shutil.rmtree(td, ignore_errors=True)
+        self.addCleanup(restore)
+        jd._SDK_OWNER_FN = None
+        path = td / (fsid + ".jsonl")
+        human = []
+        for name in sorted(G.SINGLE_FILE):                                # a scenario with two human prompts
+            records, sent = G.SINGLE_FILE[name]
+            path.write_text("\n".join(json.dumps(r) for r in records()) + "\n")
+            self.fresh(); em._CKPT_DIR_FN = None; jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+            try:
+                tree = jd.parsed_session(fsid, [str(path)], NOW)
+            finally:
+                em.set_checkpoint_dir(lambda: self.ck)
+            segs = [seg for t in tree["turns"] for seg in em.segments(t)]
+            human = [seg for seg in segs if jd._seg_human(seg) and jd._prompt_text(seg["atoms"])]
+            if len(human) >= 2:
+                break
+        self.assertGreaterEqual(len(human), 2, "a golden scenario with two human segments")
+        phantom, prompt = human[0], human[1]
+        real_plan, real_text = saved[0], saved[1]
+        def stub_units(session, store=None, floor=jd._UNSET_FLOOR, lazy_text=False):
+            return [(phantom["id"], "work", phantom["t"], None, True, None, jd._seg_anchor(phantom), None),
+                    (prompt["id"], "prompt", prompt["t"], jd._prompt_text(prompt["atoms"]), True, None, jd._seg_anchor(prompt), None)]
+        jd.plan_units = stub_units
+        jd.unit_text_for = lambda seg, phase: "" if (seg["id"] == phantom["id"] and phase == "work") else real_text(seg, phase)
+        calls = []
+        jd.opener_llm = lambda text, menu_text, sibling_num=None: (calls.append(text), "")[1]   # a blank plan: the coerced place
+        jd._plan_session(fsid, str(path), NOW)
+        store = jd.load_goals(fsid)
+        pk, uk = jd._unit_key(phantom["id"], "work"), jd._unit_key(prompt["id"], "prompt")
+        self.assertIn(pk, store["placements"]); self.assertIsNone(store["placements"][pk], "the phantom's OWN key retired")
+        self.assertEqual(len(calls), 1, "the prompt unit reached the opener once: %r" % calls)
+        self.assertIsNotNone(store["placements"].get(uk), "the prompt planned and placed: %r" % {k: v for k, v in store["placements"].items()})
 
     def test_the_nudge_gates_except_leg_is_counted_and_not_entered_by_a_widened_stub(self):
         """Round three, low 3: six test modules stubbed plan_units without the keyword; the gate's except swallowed the TypeError

--- a/tests/test_skill_load_wrapper.py
+++ b/tests/test_skill_load_wrapper.py
@@ -708,7 +708,7 @@ class NudgeWalkSkips(unittest.TestCase):
         km._all_outstanding_delegated = lambda nodes, gid: False
         km._pending_ops = {}
         jd._segs = lambda tn, store: []
-        jd.plan_units = lambda session, store: []
+        jd.plan_units = lambda session, store, **kw: []   # the callers pass lazy_text (T396)
         uid = "u-t1"
         turns = [{"id": "t1", "t": self.ARM_T, "end": self.ARM_T + 60, "ended": True, "trigger": {"uuid": uid},
                   "atoms": [{"uuid": uid, "type": "user", "author": "human", "t": self.ARM_T}]}]

--- a/tests/test_wake_answer_files_under_shared_view.py
+++ b/tests/test_wake_answer_files_under_shared_view.py
@@ -99,7 +99,7 @@ class AnsweredWakeFilesWhenItsCallerHoldsTheSharedView(unittest.TestCase):
         # the judges ruled on the wake's response: the answered leg is the one under test
         km._nudge_response_ready = lambda *a, **k: (True, {"id": "s9", "t": ANSWER})
         jd._segs = lambda tn, store: []
-        jd.plan_units = lambda session, store: []
+        jd.plan_units = lambda session, store, **kw: []   # the callers pass lazy_text (T396)
         self.turns = [{"id": "t1", "ended": True, "end": 100, "t": 90, "atoms": []}]
         jd.parsed_session = lambda sid, paths, now: {"turns": self.turns}
         self.fb = _FakeBackend()


### PR DESCRIPTION
Fix tier: four review lows on the lazy planner (the previous change), two with tests that fail before them.

**Low 1, the gate's blind spots.** `_unit_nonempty` said non-empty on two shapes no writer here produces where `_unit_text` gives an empty string: a tool call with a missing or empty name, and an assistant message whose content is a bare string. The lazy road then yielded a work unit the eager road never did, the plan pass read its text as empty and skipped it, wrote no placement and no retirement, and the nudge placement gate read that key as unplanned on every tick, silencing the session's escalation ladder. Two hardenings: the gate frames a tool call only with a name, as `_unit_text` does; and the plan pass RETIRES a unit whose late-read text comes back empty instead of skipping it, which closes the wedge for every future blind spot (the bare-string case cannot be settled from scalars, since the text scalar is computed from the normalized content).

**Low 2, one text rule.** A workless follow-up's eager text was the bare seam text while its lazy text went through `unit_text_for`, which prepends the work note; unreachable today, but the two roads are now one rule by construction (the workless follow-up takes the work unit's note-plus-text function).

**Low 3, the stubs.** Six test modules still stubbed `plan_units` without the keyword; the nudge gate's except leg swallowed the TypeError into a stderr trace and answered not unplanned, and the modules stayed green by accident. Each stub takes the keyword now, the gate counts its except leg (`memos.nudgeGate.failed`), and a test pins that a widened stub never enters it while a narrow one does; the module set's log carries zero gate tracebacks.

**Low 4, the pin and the comparison.** The caller pin covers all three call sites by source (the plan pass twice, the fast-forward on unmute, the kernel's nudge gate) with the dead hasattr branch gone; a new test compares the lazy units to the eager ones in every field, over every golden scenario whole and restored, after resolving the lazy text and quote as the plan pass does.

**Red-first at the base:** the blind-spot test fails "True is not false : a nameless tool call is not framed"; the except-leg test fails "0 != 1 : a narrow stub: the leg entered and counted". The caller pin and the whole-unit comparison are pins, green at the base by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)