### PR TITLE
The landing-rule table pins its webview twin as executed, and carries the one producible pair it left out

### DIFF
--- a/tests/test_card_summary_anchor.py
+++ b/tests/test_card_summary_anchor.py
@@ -164,7 +164,9 @@ class TheLineRuleTable(unittest.TestCase):
             self.assertIn(row, ts, "the webview pins the same row: %s" % row)
         # PRESENT is not EXECUTED (the manager's read of the merge): the rows must be driven through distillInputs by a
         # test that stands beside them, or a deleted test block with the array kept would leave this pin green
-        call = ts.index('test("distillInputs over the states the kernel\'s landing rule mirrors", () => {')
+        head = 'test("distillInputs over the states the kernel\'s landing rule mirrors", () => {'
+        self.assertIn(head, ts, "the webview TEST that drives the table exists (present rows are not executed rows)")
+        call = ts.index(head)
         self.assertGreater(call, table, "the test stands beside the table it drives")
         block = ts[call:]
         self.assertIn("for (const [name, state, column, completed, blocked] of LINE_RULE_TABLE)", block, "the test walks the table")

--- a/tests/test_card_summary_anchor.py
+++ b/tests/test_card_summary_anchor.py
@@ -133,7 +133,7 @@ class TheTextAtom(unittest.TestCase):
         self.assertEqual(first[0], "t5")
 
 
-# The six states the verifier executed, one row each: (name, distillState, column, completed, blocked). The webview
+# The states the verifier executed plus the one producible pair they left out, one row each: (name, distillState, column, completed, blocked). The webview
 # test ui/webview/distiller-line.test.ts carries the SAME rows for distillInputs; TheLineRuleTable pins both sides.
 LINE_RULE_TABLE = [
     ("stall floor", None, "needs_input", False, True),
@@ -142,6 +142,7 @@ LINE_RULE_TABLE = [
     ("done confirming", None, "working", False, False),
     ("completed", "completed", "completed", True, False),
     ("plain working", None, "working", False, False),
+    ("completed under a needs-input column", "completed", "needs_input", True, False),   # the producible pair the six named states left untabled
 ]
 
 
@@ -154,12 +155,20 @@ class TheLineRuleTable(unittest.TestCase):
                 self.assertEqual(got_completed, completed, name)
                 self.assertEqual(line, "the brief" if blocked else ("the takeaway" if completed else None), name)
 
-    def test_the_webview_test_carries_the_same_table(self):
+    def test_the_webview_test_carries_the_same_table_and_executes_it(self):
         ts = open(os.path.join(ROOT, "ui", "webview", "distiller-line.test.ts"), encoding="utf-8").read()
+        table = ts.index("const LINE_RULE_TABLE:")
         for name, state, column, completed, blocked in LINE_RULE_TABLE:
             row = '["%s", %s, "%s", %s, %s]' % (name, "null" if state is None else '"%s"' % state, column,
                                                 str(completed).lower(), str(blocked).lower())
             self.assertIn(row, ts, "the webview pins the same row: %s" % row)
+        # PRESENT is not EXECUTED (the manager's read of the merge): the rows must be driven through distillInputs by a
+        # test that stands beside them, or a deleted test block with the array kept would leave this pin green
+        call = ts.index('test("distillInputs over the states the kernel\'s landing rule mirrors", () => {')
+        self.assertGreater(call, table, "the test stands beside the table it drives")
+        block = ts[call:]
+        self.assertIn("for (const [name, state, column, completed, blocked] of LINE_RULE_TABLE)", block, "the test walks the table")
+        self.assertIn("assert.deepEqual(distillInputs(state, column), { completed, blocked }, name);", block, "…and asserts each row through distillInputs")
 
 
 class TheWiring(unittest.TestCase):

--- a/ui/webview/distiller-line.test.ts
+++ b/ui/webview/distiller-line.test.ts
@@ -120,7 +120,7 @@ test("an open/working card (neither completed nor blocked) is never distill-pend
   assert.equal(distillPending(false, false, null, null), false);
 });
 
-// The six states the kernel's _landing_inputs mirrors term for term (T388): the SAME rows sit in
+// The states the kernel's _landing_inputs mirrors term for term (T388), one producible pair added: the SAME rows sit in
 // tests/test_card_summary_anchor.py LINE_RULE_TABLE, and the Python test pins that this file carries them.
 const LINE_RULE_TABLE: Array<[string, "completed" | "blocked" | null, string, boolean, boolean]> = [
   ["stall floor", null, "needs_input", false, true],
@@ -129,9 +129,10 @@ const LINE_RULE_TABLE: Array<[string, "completed" | "blocked" | null, string, bo
   ["done confirming", null, "working", false, false],
   ["completed", "completed", "completed", true, false],
   ["plain working", null, "working", false, false],
+  ["completed under a needs-input column", "completed", "needs_input", true, false],   // the producible pair the six left out
 ];
 
-test("distillInputs over the six states the kernel's landing rule mirrors", () => {
+test("distillInputs over the states the kernel's landing rule mirrors", () => {
   for (const [name, state, column, completed, blocked] of LINE_RULE_TABLE) {
     assert.deepEqual(distillInputs(state, column), { completed, blocked }, name);
   }


### PR DESCRIPTION
## What

Two test-robustness lows from the manager's read of the merged card fix.

- The Python pin over the webview file proved the rows present, not executed: deleting the webview test block while keeping the array left it green. The pin now finds the test that stands beside the table, after it, and the two lines that walk the rows and assert each one through the client's rule.
- The six named states were five distinct input pairs; the producible pair, a completed distill state under a needs-input column, is tabled on both sides with the value both rules give: completed, not blocked.

## Tests

Red first at the merged base: the new row's cross-file pin fails there (the webview table lacks it); with the row present, deleting the webview test block turns the executed-test pin red while the old presence pin stayed green.

Tier: fix