### PR TITLE
The tab widgets' second review round: the section scroll reaches the top, one pending ask, a plain open resets, the declared VS Code floor, one keycap rule, a seeded percentage (T379 follow-up)

### DIFF
--- a/tests/test_kernel_session_color.py
+++ b/tests/test_kernel_session_color.py
@@ -155,7 +155,7 @@ class SessionColor(unittest.TestCase):
         self.assertIn("id=rs-pal-btn", html)
         self.assertIn("id=rs-pal-list", html)
         self.assertIn("{ type: 'setPalette', name: name }", _gear_src())
-        self.assertIn("plFill(); fill(); showSection(section); }", _gear_src(),   # the opener ends on the section scroll since T379
+        self.assertIn("plFill(); fill(); if (section) showSection(section); else clearSectionScroll(); }", _gear_src(),   # the opener ends on the section scroll since T379
                       "gear open re-reads the server-authoritative choice from /palette")
 
 

--- a/tests/test_tab_widgets_browser.py
+++ b/tests/test_tab_widgets_browser.py
@@ -281,7 +281,8 @@ class ServedTabWidgets(unittest.TestCase):
             Path(state, "names", sid).write_text("%s\t%s\t%s\t%s\n" % (name, cwd, bg, fg))
             Path(state, "sdk", sid + ".json").write_text(json.dumps(
                 {"sid": sid, "name": name, "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": sid, "alive": True,
-                 "model": "claude-opus-5", "liveModel": "Opus 5"}))
+                 "model": "claude-opus-5", "liveModel": "Opus 5",
+                 **({"liveCtx": 62} if name == "web" else {})}))   # web carries a context percentage, so the context bar has something to show (round two, LOW 6)
             recs = [{"type": "user", "timestamp": iso(t0 + i), "uuid": "u1", "parentUuid": None, "promptSource": "typed", "sessionId": sid,
                      "message": {"role": "user", "content": "what does the %s session do in notes-api?" % name}},
                     {"type": "assistant", "timestamp": iso(t0 + i + 5), "uuid": "a1", "parentUuid": "u1", "sessionId": sid,
@@ -366,7 +367,9 @@ class ServedTabWidgets(unittest.TestCase):
         self.assertIsNotNone(web["key"], "web's hot key (the tab hot-key store) renders as a keycap" + table)
         self.assertEqual(web["key"]["text"], "⌃⇧1", table)
         self.assertGreater(web["key"]["w"], 10, table)
-        self.assertEqual(web["children"].index("tab-key"), web["children"].index("tab-label") + 1, "the keycap follows the name" + table)
+        self.assertTrue(web["ctx"], "web carries a context percentage (62): the bar shows from half full" + table)
+        self.assertEqual(web["children"].index("tab-ctx"), web["children"].index("tab-label") + 1, "the bar follows the name" + table)
+        self.assertEqual(web["children"].index("tab-key"), web["children"].index("tab-ctx") + 1, "the keycap follows the bar (registration order)" + table)
         api = next(t for t in s["tabs"] if t["name"].endswith("api"))
         self.assertIsNone(api["key"], "no hot key assigned: no keycap" + table)
         self.assertIsNotNone(s["gear"], "the glyph is in the strip (the chat sits in the shell, so a gear can be reached)" + table)
@@ -382,11 +385,8 @@ class ServedTabWidgets(unittest.TestCase):
         self.assertLess(sec["top"], sec["cardBottom"], "the head is inside the card's box" + table)
         if sec["overflow"] > 0:
             self.assertGreater(sec["scrollTop"], 0, "the card scrolled" + table)
-            at_top = abs(sec["top"] - (sec["cardTop"] + sec["pad"])) < 3
-            # the scroll rides the card's first size (the shell lifts the iframe after a message round trip); a late layout
-            # after that first size (fonts, the model lists filling) can grow the pane by a pixel or two, so the scroll end
-            # is read with that much slack (measured 198 of 200 on the first open, 200 of 200 on a re-ask)
-            self.assertTrue(at_top or sec["scrollTop"] >= sec["overflow"] - 4, "the head sits under the card's padding, or the card is at its scroll end" + table)
+            # round two, LOW 1: the head sits under the card's padding, always: the pane gains room at its end for it
+            self.assertLess(abs(sec["top"] - (sec["cardTop"] + sec["pad"])), 3, "the head sits under the card's padding" + table)
 
     def test_the_glyph_opens_the_settings_on_the_chat_tab_scrolled_to_the_tab_widgets_section_with_the_other_panes_hidden(self):
         r = self._run()
@@ -442,6 +442,7 @@ class ServedTabWidgets(unittest.TestCase):
             self.assertEqual((sc["panelBefore"]["checked"], sc["panelBefore"]["show"]), (checked, show), mode + ": the row reads the older setting" + table)
             self.assertEqual(sc["after"]["store"], {"tabWidgets": "absent", "tabCtx": mode, "compact": False}, mode + ": Compact saved; the widgets key still absent, the mirror untouched" + table)
             self.assertEqual(sc["after"]["ctx"], sc["before"]["ctx"], mode + ": the strip unchanged" + table)
+            self.assertEqual(any(sc["before"]["ctx"]), mode == "always", mode + ": the seeded percentage shows exactly when the older setting says so (the assertion above is not vacuous)" + table)
             self.assertEqual(sc["panelAfter"], sc["panelBefore"], mode + ": the row unchanged" + table)
 
     def test_a_switch_writes_the_prefs_and_the_mirror_and_the_strip_follows_live(self):
@@ -452,6 +453,7 @@ class ServedTabWidgets(unittest.TestCase):
         self.assertEqual([x["sw"]["checked"] for x in a["panel"]["rows"]], ["true", "false", "true"], "the Context bar's switch is off" + table)
         self.assertEqual(a["strip"]["store"]["tabWidgets"]["on"], {"ctx": False}, "the store's prefs" + table)
         self.assertEqual(a["strip"]["store"]["tabCtx"], "never", "…and the older key mirrors it, for older readers" + table)
+        self.assertFalse(a["strip"]["web"]["ctx"], "the bar left web's tab live" + table)
         k = r["afterKeyOff"]["strip"]
         self.assertIsNone(k["web"]["key"], "the hot key widget off: the keycap left web's tab, live, through the storage event: " + json.dumps(k["web"]))
         self.assertEqual(k["store"]["tabWidgets"]["on"], {"ctx": True, "hotkey": False}, "the bar's flag was written back on, the hot key's off: " + json.dumps(k["store"]))
@@ -482,6 +484,8 @@ class ServedTabWidgets(unittest.TestCase):
         ro = r["reopen"]
         self.assertTrue(ro["open"], "the rail's gear reopened it")
         self.assertEqual([x["pane"] for x in ro["panes"] if x["display"] != "none"], ["chat"], "…on the remembered tab (Chat was picked last)")
+        # round two, LOW 2 and 7: a plain open (no section) starts at the card's top, and the earlier ask's observer never fires again
+        self.assertEqual(ro["section"]["scrollTop"], 0, "a plain open resets the card; no stale section scroll: " + json.dumps(ro["section"]))
 
 
 if __name__ == "__main__":

--- a/tests/test_tab_widgets_browser.py
+++ b/tests/test_tab_widgets_browser.py
@@ -104,11 +104,15 @@ for (let i = 0; i < 50 && !setF; i++) { await page.waitForTimeout(100); setF = p
 if (!setF) {   // no settings frame opened (the red run's before: no glyph, no ask): every later reading is an honest empty, so each test fails on its own assertion
   const none = { open: false, pills: [], panes: [], rows: [], remembered: null, section: null };
   Object.assign(out, { panel0: none, afterCtxOff: { panel: none, strip: out.strip0 }, dotOpt: { present: false, picked: false, labels: [] }, afterGrey: { panel: none, strip: out.strip0 },
-                       afterKeyOff: { strip: out.strip0 }, feedPane: none, reask: none, afterEscape: { shellOpen: false, panel: none }, reopen: none, legacy: {} });
+                       afterKeyOff: { strip: out.strip0 }, feedPane: none, pillBack: none, reask: none, afterEscape: { shellOpen: false, panel: none }, reopen: none, legacy: {}, tall: { open: null, reask: null } });
   fs.writeFileSync(cfg.out, JSON.stringify(out)); console.log("RESULT: ok"); await browser.close(); process.exit(0);
 }
 await setF.waitForSelector("#rsettings:not([hidden])", { timeout: 15000 }).catch(() => {});
-await setF.waitForTimeout(300);
+await setF.evaluate(() => (document.fonts && document.fonts.ready) || null).catch(() => {});   // the layout the measurement reads is the settled one (a late web font moved the head on a slow runner)
+// the landing's own mark, never a delay: the gear stamps the card when the section scroll lands (CI, 2026-09-13: a fixed wait read before it)
+const landed = (frame) => frame.waitForSelector('#rsettings .rs-card[data-section-landed="tabwidgets"]', { timeout: 10000 }).then(() => true).catch(() => false);
+out.landed0 = await landed(setF);
+await setF.waitForTimeout(150);
 const readPanel = () => setF.evaluate(() => {
   const p = document.getElementById("rsettings");
   if (!p || p.hidden) return { open: false };
@@ -127,7 +131,8 @@ const readPanel = () => setF.evaluate(() => {
   const card = document.querySelector("#rsettings .rs-card"); const sec = document.querySelector('#rsettings .rs-sec[data-section="tabwidgets"]');
   const cr = card.getBoundingClientRect(); const sr = sec ? sec.getBoundingClientRect() : null;
   const section = sec ? { top: sr.top, cardTop: cr.top, cardBottom: cr.bottom, pad: parseFloat(getComputedStyle(card).paddingTop), scrollTop: card.scrollTop, overflow: card.scrollHeight - card.clientHeight,
-                          inChat: !!sec.closest('.rs-pane[data-pane="chat"]'), paneHidden: sec.closest(".rs-pane").hidden } : null;
+                          inChat: !!sec.closest('.rs-pane[data-pane="chat"]'), paneHidden: sec.closest(".rs-pane").hidden,
+                          room: parseFloat(getComputedStyle(sec.closest(".rs-pane")).paddingBottom) || 0, cardH: cr.height, viewportH: window.innerHeight } : null;
   return { open: true, pills, panes, rows, remembered: localStorage.getItem("romp:settingsTab"), section };
 });
 out.panel0 = await readPanel();
@@ -156,9 +161,12 @@ await flip("hotkey");
 // the pills: Feed hides Chat; Escape closes; the next open remembers the tab
 await setF.click('#rsettings .rs-tab[data-tab="feed"]'); await setF.waitForTimeout(150);
 out.feedPane = await readPanel();
+// a pill round trip (Feed, then Chat by its pill): the Chat pane comes back at its top with no section room left behind
+await setF.click('#rsettings .rs-tab[data-tab="chat"]'); await setF.waitForTimeout(150);
+out.pillBack = await readPanel();
 // an ask on an OPEN panel (through the shell's relay, the path the glyph's message takes; the lifted settings iframe covers the
 // strip while the panel is open, so the glyph itself is not reachable by a pointer then): switches back to Chat and scrolls
-await page.evaluate(() => window.__rompOpenSettings("chat", "tabwidgets")); await setF.waitForTimeout(300);
+await page.evaluate(() => window.__rompOpenSettings("chat", "tabwidgets")); out.landedReask = await landed(setF); await setF.waitForTimeout(150);
 out.reask = await readPanel();
 // the screenshots: the strip with the glyph and the Chat tab at its Tab widgets section, dark then light
 const shot = async (theme) => {
@@ -227,6 +235,30 @@ for (const mode of ["always", "never"]) {
   await sf.click("#rs-compact"); await sf.waitForTimeout(500);   // an unrelated setting's save
   out.legacy[mode] = { before, shellBefore, panelBefore, after: await strip(), panelAfter: await row() };
   await p2.close(); await c2.close();
+}
+// a TALL window (the follow-up's round one, MEDIUM): below its cap the card grows under any room added, so the head stopped
+// short (152px off at 1200px); the room is sized to the cap now. The glyph's open and a re-ask, measured at 1200 by 1200.
+{
+  const c3 = await browser.newContext({ viewport: { width: 1200, height: 1200 } });
+  const p3 = await c3.newPage(); await p3.goto(cfg.url); await p3.waitForSelector("#rail-gear", { timeout: 20000 });
+  let cf3 = p3.frames().find((f) => f.url().includes("/chat"));
+  for (let i = 0; i < 100 && !cf3; i++) { await p3.waitForTimeout(100); cf3 = p3.frames().find((f) => f.url().includes("/chat")); }
+  await cf3.waitForFunction((n) => document.querySelectorAll("#tabs .tab[data-id]").length >= n, cfg.count, { timeout: 30000 });
+  await p3.evaluate(() => window.__rompOpenSettings("chat", "tabwidgets"));
+  await p3.waitForFunction(() => document.body.classList.contains("settings-open"), null, { timeout: 20000 }).catch(() => {});
+  let sf3 = p3.frames().find((f) => f.url().includes("/settings"));
+  for (let i = 0; i < 50 && !sf3; i++) { await p3.waitForTimeout(100); sf3 = p3.frames().find((f) => f.url().includes("/settings")); }
+  await sf3.waitForSelector("#rsettings:not([hidden])", { timeout: 15000 }).catch(() => {});
+  await sf3.evaluate(() => (document.fonts && document.fonts.ready) || null).catch(() => {});
+  out.tallLanded = await landed(sf3); await sf3.waitForTimeout(150);
+  const readSec = () => sf3.evaluate(() => { const card = document.querySelector("#rsettings .rs-card"); const sec = document.querySelector('#rsettings .rs-sec[data-section="tabwidgets"]');
+    if (!card || !sec) return null; const cr = card.getBoundingClientRect(), sr = sec.getBoundingClientRect();
+    return { top: sr.top, cardTop: cr.top, cardBottom: cr.bottom, pad: parseFloat(getComputedStyle(card).paddingTop), scrollTop: card.scrollTop, overflow: card.scrollHeight - card.clientHeight,
+             room: parseFloat(getComputedStyle(sec.closest(".rs-pane")).paddingBottom) || 0, cardH: cr.height, viewportH: window.innerHeight, inChat: true, paneHidden: sec.closest(".rs-pane").hidden }; });
+  out.tall = { open: await readSec() };
+  await p3.evaluate(() => window.__rompOpenSettings("chat", "tabwidgets")); await landed(sf3); await sf3.waitForTimeout(150);
+  out.tall.reask = await readSec();
+  await p3.close(); await c3.close();
 }
 fs.writeFileSync(cfg.out, JSON.stringify(out));
 await browser.close();
@@ -379,6 +411,7 @@ class ServedTabWidgets(unittest.TestCase):
     def _assert_scrolled_to_the_section(self, p, table):
         # the section head sits inside the card's visible box, under its padding, unless the card ran out of scroll first
         sec = p["section"]
+        table = "\n  section=" + json.dumps(sec) + table   # the numbers first: the panel's table is long and cut
         self.assertIsNotNone(sec, "the Tab widgets head carries the section anchor" + table)
         self.assertTrue(sec["inChat"] and not sec["paneHidden"], "the section is in the Chat pane, which is shown" + table)
         self.assertGreaterEqual(sec["top"], sec["cardTop"] - 0.5, "the head is not above the card's box" + table)
@@ -402,6 +435,7 @@ class ServedTabWidgets(unittest.TestCase):
         self.assertEqual([x["pane"] for x in shown], ["chat"], "one pane painted" + table)
         self.assertTrue(all(x["rows"] > 0 for x in p["panes"]), "every pane holds rows" + table)
         self.assertEqual(p["remembered"], "chat", table)
+        self.assertTrue(r["landed0"], "the gear marked the landing before the measurement (the lab waits for the event, never a delay)")
         self._assert_scrolled_to_the_section(p, table)
 
     def test_each_widget_row_shows_a_live_demo_drawn_by_the_strips_render_a_sliding_switch_and_its_options(self):
@@ -476,6 +510,11 @@ class ServedTabWidgets(unittest.TestCase):
         self.assertEqual(shown, ["feed"], json.dumps(c["panes"]))
         self.assertEqual(c["remembered"], "feed")
         self.assertTrue(c["section"]["paneHidden"], "the Tab widgets section is in the hidden Chat pane now")
+        # the follow-up's round one, LOW 1: a pill round trip (Feed, then Chat by its pill) leaves no section room on the Chat pane
+        pb = r["pillBack"]
+        self.assertEqual([x["pane"] for x in pb["panes"] if x["display"] != "none"], ["chat"], json.dumps(pb["panes"]))
+        self.assertEqual(pb["section"]["room"], 0, "the Chat pane comes back with no room left behind: " + json.dumps(pb["section"]))
+        self.assertEqual(pb["section"]["scrollTop"], 0, "…at its top: " + json.dumps(pb["section"]))
         a = r["reask"]
         self.assertEqual([x["pane"] for x in a["panes"] if x["display"] != "none"], ["chat"], "the glyph on an open panel switches back to Chat: " + json.dumps(a["panes"]))
         self._assert_scrolled_to_the_section(a, "\n  " + json.dumps(a["section"]))
@@ -486,6 +525,17 @@ class ServedTabWidgets(unittest.TestCase):
         self.assertEqual([x["pane"] for x in ro["panes"] if x["display"] != "none"], ["chat"], "…on the remembered tab (Chat was picked last)")
         # round two, LOW 2 and 7: a plain open (no section) starts at the card's top, and the earlier ask's observer never fires again
         self.assertEqual(ro["section"]["scrollTop"], 0, "a plain open resets the card; no stale section scroll: " + json.dumps(ro["section"]))
+
+    def test_a_tall_window_lands_the_head_under_the_padding_too(self):
+        # the follow-up's round one, MEDIUM: below its cap the card grew under the room and the head stopped 152px short at a
+        # 1200px window; the room is sized to the card's cap now, so the first open and a re-ask land the head at the top
+        t = self._run()["tall"]
+        for k in ("open", "reask"):
+            sec = t[k]
+            table = "\n  " + json.dumps(sec)
+            self.assertIsNotNone(sec, k + ": the tall scene ran" + table)
+            self.assertGreaterEqual(sec["viewportH"], 1200, table)
+            self.assertLess(abs(sec["top"] - (sec["cardTop"] + sec["pad"])), 3, k + ": the head sits under the card's padding at 1200px" + table)
 
 
 if __name__ == "__main__":

--- a/ui/webview/gear-tabs.test.ts
+++ b/ui/webview/gear-tabs.test.ts
@@ -77,22 +77,29 @@ test("selectTab shows one pane, marks its pill, remembers it per browser; openSe
   assert.match(GEAR, /b\.classList\.toggle\('on', on\); b\.setAttribute\('aria-selected', on \? 'true' : 'false'\);/);
   assert.match(GEAR, /pn\.hidden = pn\.getAttribute\('data-pane'\) !== t;/);
   assert.match(GEAR, /try \{ localStorage\.setItem\(TAB_KEY, t\); \} catch \(e\) \{\}/);
-  assert.match(GEAR, /function openSettings\(tab, section\) \{\s*\n\s*if \(!p\.hidden\) \{ if \(knownTab\(tab\)\) \{ selectTab\(tab\); showSection\(section\); return; \} closeSettings\(\); return; \}/,
+  assert.match(GEAR, /function openSettings\(tab, section\) \{\s*\n\s*if \(!p\.hidden\) \{ if \(knownTab\(tab\)\) \{ selectTab\(tab\); if \(section\) showSection\(section\); else clearSectionScroll\(\); return; \} closeSettings\(\); return; \}/,
     "a named tab on an open panel switches to it and scrolls to its section; a bare ask still toggles");
   assert.match(GEAR, /if \(e\.data && e\.data\.romp === 'openSettings'\) openSettings\(typeof e\.data\.tab === 'string' \? e\.data\.tab : undefined, typeof e\.data\.section === 'string' \? e\.data\.section : undefined\);/, "the tab and the section ride the message");
   // the SECTION anchor (the user's amendment 2026-09-12): looked up in the shown pane only; the card, the modal's one scroll box, scrolls so the head
   // sits under its padding (never scrollIntoView, which would scroll the host document too); after the panel is shown, since rects exist only then
-  assert.match(GEAR, /function showSection\(section\) \{\s*\n\s*if \(typeof section !== 'string' \|\| !section\) return;\s*\n\s*var sec = document\.querySelector\('#rsettings \.rs-pane:not\(\[hidden\]\) \.rs-sec\[data-section="' \+ section \+ '"\]'\);/);
-  assert.match(GEAR, /card\.scrollTop = card\.scrollTop \+ sec\.getBoundingClientRect\(\)\.top - card\.getBoundingClientRect\(\)\.top - \(parseFloat\(getComputedStyle\(card\)\.paddingTop\) \|\| 0\);/);
+  assert.match(GEAR, /function showSection\(section\) \{\s*\n\s*if \(sectionRO\) \{ sectionRO\.disconnect\(\); sectionRO = null; \}\s*\n\s*if \(typeof section !== 'string' \|\| !section\) return;\s*\n\s*var sec = document\.querySelector\('#rsettings \.rs-pane:not\(\[hidden\]\) \.rs-sec\[data-section="' \+ section \+ '"\]'\);/);
+  assert.match(GEAR, /card\.scrollTop = card\.scrollTop \+ sec\.getBoundingClientRect\(\)\.top - card\.getBoundingClientRect\(\)\.top - padT;/);
+  // round two, LOW 1: room at the pane's end so the head reaches the top even for the last section; LOW 2 and 7: one pending ask,
+  // disconnected on close and before a new ask, and a plain open resets the card and the room
+  assert.match(GEAR, /var go = function \(\) \{\s*\n\s*pane\.style\.paddingBottom = '';/, "the room is cleared before the measurement (a re-ask must not read its own earlier room)");
+  assert.match(GEAR, /var missing = \(card\.clientHeight - padT - padB\) - \(pane\.getBoundingClientRect\(\)\.bottom - sec\.getBoundingClientRect\(\)\.top\);\s*\n\s*pane\.style\.paddingBottom = missing > 0 \? Math\.ceil\(missing\) \+ 'px' : '';/);
+  assert.match(GEAR, /function clearSectionScroll\(\) \{\s*\n\s*if \(sectionRO\) \{ sectionRO\.disconnect\(\); sectionRO = null; \}\s*\n\s*var card = document\.querySelector\('#rsettings \.rs-card'\);\s*\n\s*if \(card\) card\.scrollTop = 0;/);
+  assert.match(GEAR, /function showSection\(section\) \{\s*\n\s*if \(sectionRO\) \{ sectionRO\.disconnect\(\); sectionRO = null; \}/, "a new ask retires the pending one");
+  assert.match(GEAR, /function closeSettings\(\) \{ clearSectionScroll\(\); p\.hidden = true; setModalCls\(false\); feedFull\(false\); \}/, "the reset before the hide: a hidden card ignores a scroll write");
+  assert.match(GEAR, /sectionRO = new ResizeObserver\(function \(\) \{ if \(card\.clientHeight > 0\) \{ if \(sectionRO\) \{ sectionRO\.disconnect\(\); sectionRO = null; \} go\(\); \} \}\);\s*\n\s*sectionRO\.observe\(card\);/);
   // the first open in the shell: this document has no layout until the shell lifts its iframe on the settings-open message, so a
   // scroll set then clamps to zero (measured); the card gaining a size is the event, observed once, never a timer
   assert.match(GEAR, /if \(card\.clientHeight > 0\) \{ go\(\); return; \}/);
-  assert.match(GEAR, /var ro = new ResizeObserver\(function \(\) \{ if \(card\.clientHeight > 0\) \{ ro\.disconnect\(\); go\(\); \} \}\);\s*\n\s*ro\.observe\(card\);/);
   const showAt = GEAR.indexOf("function showSection(section) {");
   const showSec = GEAR.slice(showAt, GEAR.indexOf("\n  }\n", showAt) + 4);   // the function body alone
   assert.doesNotMatch(showSec, /setTimeout|requestAnimationFrame/, "no time-based guess at the shell's round trip");
   assert.doesNotMatch(showSec, /scrollIntoView/, "the section scroll is set on the card, never scrollIntoView (which scrolls the host document too)");
-  assert.match(GEAR, /plFill\(\); fill\(\); showSection\(section\); \}/, "the scroll is the opener's last act, after the panel is displayed");
+  assert.match(GEAR, /plFill\(\); fill\(\); if \(section\) showSection\(section\); else clearSectionScroll\(\); \}/, "the scroll (or the reset) is the opener's last act, after the panel is displayed");
   assert.match(GEAR_CSS, /#rsettings \.rs-pane\[hidden\] \{ display: none; \}/, "a hidden pane is out of the flow (the [hidden] rule the author display would beat)");
   assert.match(GEAR_CSS, /#rsettings \.rs-tab\.on \{ color: var\(--accent, #9cd2ff\); border-color: var\(--accent, #9cd2ff\); background: var\(--accent-wash, rgba\(156, 210, 255, 0\.12\)\); font-weight: 600; \}/);
 });
@@ -120,6 +127,10 @@ test("the Tab widgets section's rows come from the strip's own module: built onc
   assert.match(GEAR_CSS, /#rsettings \.rs-widgets \{ display: grid; grid-template-columns: 96px 1fr auto auto; column-gap: 10px; \}\s*\n#rsettings \.rs-widget \{ display: grid; grid-template-columns: subgrid; grid-column: 1 \/ -1;/, "one grid across the rows, each row a subgrid of it (round one, LOW 2)");
   assert.match(GEAR_CSS, /#rsettings \.rs-row:hover \.rs-sub, #rsettings \.rs-widget:hover \.rs-sub \{ display: block; position: absolute;/, "the widget rows share the panel's hover popover rule");
   assert.doesNotMatch(GEAR_CSS, /#rsettings \.rs-widget-name span \{/, "no always-painted description rule");
+  // round two, LOW 3: grid-template-columns: subgrid needs Chromium 117 and the stylesheet's oklch(from) 119; the extension's declared
+  // VS Code floor is 1.88 (Electron 28, Chromium 120), the first release that ships both
+  const pkg = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), "..", "vscode-extension", "package.json"), "utf8"));
+  assert.equal(pkg.engines.vscode, "^1.88.0", "the declared floor carries subgrid (117) and oklch(from) (119)");
   assert.match(GEAR_CSS, /#rsettings \.rs-widget-demo \.tab-dot \{ flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; background: var\(--st-working-bg, #e0b020\); \}/, "the demo wears the strip's vocabulary in this sheet's fallbacks");
 });
 

--- a/ui/webview/gear-tabs.test.ts
+++ b/ui/webview/gear-tabs.test.ts
@@ -82,19 +82,30 @@ test("selectTab shows one pane, marks its pill, remembers it per browser; openSe
   assert.match(GEAR, /if \(e\.data && e\.data\.romp === 'openSettings'\) openSettings\(typeof e\.data\.tab === 'string' \? e\.data\.tab : undefined, typeof e\.data\.section === 'string' \? e\.data\.section : undefined\);/, "the tab and the section ride the message");
   // the SECTION anchor (the user's amendment 2026-09-12): looked up in the shown pane only; the card, the modal's one scroll box, scrolls so the head
   // sits under its padding (never scrollIntoView, which would scroll the host document too); after the panel is shown, since rects exist only then
-  assert.match(GEAR, /function showSection\(section\) \{\s*\n\s*if \(sectionRO\) \{ sectionRO\.disconnect\(\); sectionRO = null; \}\s*\n\s*if \(typeof section !== 'string' \|\| !section\) return;\s*\n\s*var sec = document\.querySelector\('#rsettings \.rs-pane:not\(\[hidden\]\) \.rs-sec\[data-section="' \+ section \+ '"\]'\);/);
+  assert.match(GEAR, /function showSection\(section\) \{\s*\n\s*if \(sectionRO\) \{ sectionRO\.disconnect\(\); sectionRO = null; \}\s*\n\s*sectionAsk = null;\s*\n\s*if \(typeof section !== 'string' \|\| !section\) return;\s*\n\s*var sec = document\.querySelector\('#rsettings \.rs-pane:not\(\[hidden\]\) \.rs-sec\[data-section="' \+ section \+ '"\]'\);/);
   assert.match(GEAR, /card\.scrollTop = card\.scrollTop \+ sec\.getBoundingClientRect\(\)\.top - card\.getBoundingClientRect\(\)\.top - padT;/);
   // round two, LOW 1: room at the pane's end so the head reaches the top even for the last section; LOW 2 and 7: one pending ask,
   // disconnected on close and before a new ask, and a plain open resets the card and the room
   assert.match(GEAR, /var go = function \(\) \{\s*\n\s*pane\.style\.paddingBottom = '';/, "the room is cleared before the measurement (a re-ask must not read its own earlier room)");
-  assert.match(GEAR, /var missing = \(card\.clientHeight - padT - padB\) - \(pane\.getBoundingClientRect\(\)\.bottom - sec\.getBoundingClientRect\(\)\.top\);\s*\n\s*pane\.style\.paddingBottom = missing > 0 \? Math\.ceil\(missing\) \+ 'px' : '';/);
-  assert.match(GEAR, /function clearSectionScroll\(\) \{\s*\n\s*if \(sectionRO\) \{ sectionRO\.disconnect\(\); sectionRO = null; \}\s*\n\s*var card = document\.querySelector\('#rsettings \.rs-card'\);\s*\n\s*if \(card\) card\.scrollTop = 0;/);
+  // the follow-up's round one, MEDIUM: the room is sized to the card's CAP (max-height, a content box), since below the cap the card
+  // grows under the room and the head stops short on tall windows; a second measurement after the write takes up rounding
+  assert.match(GEAR, /var capH = parseFloat\(cs\.maxHeight\);\s*\n\s*var content = isFinite\(capH\) && capH > 0 \? capH : \(card\.clientHeight - padT - padB\);\s*\n\s*var missing = content - below\(\);\s*\n\s*pane\.style\.paddingBottom = missing > 0 \? Math\.ceil\(missing\) \+ 'px' : '';\s*\n\s*var short = \(card\.clientHeight - padT - padB\) - below\(\);\s*\n\s*if \(short > 0\) pane\.style\.paddingBottom = Math\.ceil\(Math\.max\(missing, 0\) \+ short\) \+ 'px';/);
+  assert.match(GEAR_CSS, /\n\.rs-card \{ width: min\(560px, 94%\); max-height: 88vh; overflow: auto;/, "the cap the room is sized to");
+  assert.doesNotMatch(GEAR_CSS.match(/\n\.rs-card \{[^}]*\}/)![0], /box-sizing/, "a content box: max-height caps the content, which is what the room fills");
+  assert.match(GEAR, /selectTab\(b\.getAttribute\('data-tab'\)\); clearSectionScroll\(\); \}\); \}\);/, "a pill change clears the room and starts at the top (LOW 1)");
+  assert.match(GEAR, /function clearSectionScroll\(\) \{\s*\n\s*if \(sectionRO\) \{ sectionRO\.disconnect\(\); sectionRO = null; \}\s*\n\s*sectionAsk = null;\s*\n\s*var card = document\.querySelector\('#rsettings \.rs-card'\);\s*\n\s*if \(card\) \{ card\.scrollTop = 0; card\.removeAttribute\('data-section-landed'\); \}/);
   assert.match(GEAR, /function showSection\(section\) \{\s*\n\s*if \(sectionRO\) \{ sectionRO\.disconnect\(\); sectionRO = null; \}/, "a new ask retires the pending one");
   assert.match(GEAR, /function closeSettings\(\) \{ clearSectionScroll\(\); p\.hidden = true; setModalCls\(false\); feedFull\(false\); \}/, "the reset before the hide: a hidden card ignores a scroll write");
-  assert.match(GEAR, /sectionRO = new ResizeObserver\(function \(\) \{ if \(card\.clientHeight > 0\) \{ if \(sectionRO\) \{ sectionRO\.disconnect\(\); sectionRO = null; \} go\(\); \} \}\);\s*\n\s*sectionRO\.observe\(card\);/);
+  // the ask STANDS: the head re-lands on every size change of the card or the pane (a font arriving, a list filling), until the
+  // user's own scroll, a pill change or the close ends it (CI 2026-09-13: the head landed neither at the top nor at the end)
+  assert.match(GEAR, /sectionRO = new ResizeObserver\(function \(\) \{ if \(sectionAsk === ask && card\.clientHeight > 0\) go\(\); \}\);\s*\n\s*sectionRO\.observe\(card\);\s*\n\s*sectionRO\.observe\(pane\);/);
+  assert.match(GEAR, /ask\.top = card\.scrollTop;/, "the ask remembers what it set, so its own scroll event is not the user's");
+  assert.match(GEAR, /card\.setAttribute\('data-section-landed', section\);/, "a landing is marked on the card, so a lab waits for the event, never a delay");
+  assert.match(GEAR, /if \(card\) \{ card\.scrollTop = 0; card\.removeAttribute\('data-section-landed'\); \}/, "…and the mark goes with the ask");
+  assert.match(GEAR, /card\.addEventListener\('scroll', function \(\) \{ if \(sectionAsk && Math\.abs\(card\.scrollTop - sectionAsk\.top\) > 1\) \{ if \(sectionRO\) \{ sectionRO\.disconnect\(\); sectionRO = null; \} sectionAsk = null; \} \}\);/, "the user's scroll ends the ask");
   // the first open in the shell: this document has no layout until the shell lifts its iframe on the settings-open message, so a
   // scroll set then clamps to zero (measured); the card gaining a size is the event, observed once, never a timer
-  assert.match(GEAR, /if \(card\.clientHeight > 0\) \{ go\(\); return; \}/);
+  assert.match(GEAR, /if \(card\.clientHeight > 0\) go\(\);   \/\/ laid out already/, "the first landing when the panel already has a layout; the ask then stands (no return: the observer still watches)");
   const showAt = GEAR.indexOf("function showSection(section) {");
   const showSec = GEAR.slice(showAt, GEAR.indexOf("\n  }\n", showAt) + 4);   // the function body alone
   assert.doesNotMatch(showSec, /setTimeout|requestAnimationFrame/, "no time-based guess at the shell's round trip");
@@ -131,6 +142,8 @@ test("the Tab widgets section's rows come from the strip's own module: built onc
   // VS Code floor is 1.88 (Electron 28, Chromium 120), the first release that ships both
   const pkg = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), "..", "vscode-extension", "package.json"), "utf8"));
   assert.equal(pkg.engines.vscode, "^1.88.0", "the declared floor carries subgrid (117) and oklch(from) (119)");
+  const lock = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), "..", "vscode-extension", "package-lock.json"), "utf8"));
+  assert.equal(lock.packages[""].engines.vscode, "^1.88.0", "the lockfile's root agrees, so the first install after the merge rewrites nothing (LOW 2)");
   assert.match(GEAR_CSS, /#rsettings \.rs-widget-demo \.tab-dot \{ flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; background: var\(--st-working-bg, #e0b020\); \}/, "the demo wears the strip's vocabulary in this sheet's fallbacks");
 });
 

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -518,21 +518,42 @@ function initGear(post, opts) {
   // head; the strip's tab-widgets gear asks for chat / tabwidgets), and the card scrolls so that head sits at its top, under
   // the padding. Looked up in the SHOWN pane only, after the panel is displayed (rects exist only then). Set on the card,
   // the modal's one scroll box, never scrollIntoView, which would scroll the host document too.
+  // the one pending section ask (round two, LOW 2): an observer registered for an unlaid-out ask is disconnected on close and
+  // before a new ask, so a later open never fires a stale scroll; a plain open (no section) resets the card (LOW 7)
+  var sectionRO = null;
+  function clearSectionScroll() {
+    if (sectionRO) { sectionRO.disconnect(); sectionRO = null; }
+    var card = document.querySelector('#rsettings .rs-card');
+    if (card) card.scrollTop = 0;
+    Array.prototype.forEach.call(document.querySelectorAll('#rsettings .rs-pane'), function (pn) { pn.style.paddingBottom = ''; });
+  }
   function showSection(section) {
+    if (sectionRO) { sectionRO.disconnect(); sectionRO = null; }
     if (typeof section !== 'string' || !section) return;
     var sec = document.querySelector('#rsettings .rs-pane:not([hidden]) .rs-sec[data-section="' + section + '"]');
     var card = document.querySelector('#rsettings .rs-card');
-    if (!sec || !card) return;
-    var go = function () { card.scrollTop = card.scrollTop + sec.getBoundingClientRect().top - card.getBoundingClientRect().top - (parseFloat(getComputedStyle(card).paddingTop) || 0); };
+    var pane = sec && sec.closest('.rs-pane');
+    if (!sec || !card || !pane) return;
+    var go = function () {
+      pane.style.paddingBottom = '';   // measure the pane's own end: a re-ask on an already roomed pane must not read its earlier room
+      var cs = getComputedStyle(card), padT = parseFloat(cs.paddingTop) || 0, padB = parseFloat(cs.paddingBottom) || 0;
+      // room at the pane's END so the head can reach the top even when the section is the last thing in the pane (round two,
+      // LOW 1: the scroll used to stop at the card's end with the head far below the padding): the pane grows by what is
+      // missing below the section, cleared on close or a plain open
+      var missing = (card.clientHeight - padT - padB) - (pane.getBoundingClientRect().bottom - sec.getBoundingClientRect().top);
+      pane.style.paddingBottom = missing > 0 ? Math.ceil(missing) + 'px' : '';
+      card.scrollTop = card.scrollTop + sec.getBoundingClientRect().top - card.getBoundingClientRect().top - padT;
+    };
     if (card.clientHeight > 0) { go(); return; }   // laid out already: an open panel, or a host that never hides this document
     // Not laid out yet: in the shell this document sits in an iframe that is display:none until the shell hears the
     // settings-open message feedFull just posted, and a scroll set on a box with no size clamps to zero (the served lab
     // measured 0 on the first open). The card gaining a size IS the event that says the panel is visible, so the
     // scroll rides it, once. No timer: a frame or a delay would guess at the shell's round trip.
     if (typeof ResizeObserver !== 'function') return;
-    var ro = new ResizeObserver(function () { if (card.clientHeight > 0) { ro.disconnect(); go(); } });
-    ro.observe(card);
+    sectionRO = new ResizeObserver(function () { if (card.clientHeight > 0) { if (sectionRO) { sectionRO.disconnect(); sectionRO = null; } go(); } });
+    sectionRO.observe(card);
   }
+
   // ── THE WIDGET ROWS (T379) ── one per registered widget: the live demo (a miniature tab rendering the widget over a
   // synthetic status through the SAME render the strip uses), the name and what it does, the sliding switch, and the
   // widget's own options as house pickers. Built once; every paint re-fills in place (click-safe). A change writes
@@ -1391,16 +1412,16 @@ function initGear(post, opts) {
       document.body.classList.remove('rs-lifted'); document.body.classList.remove('rs-pane-gone');
       clearPaneVars();
       window.removeEventListener('resize', onRsResize); } }
-  function closeSettings() { p.hidden = true; setModalCls(false); feedFull(false); }
+  function closeSettings() { clearSectionScroll(); p.hidden = true; setModalCls(false); feedFull(false); }   // the reset FIRST, while the card still has a layout: a hidden card ignores a scroll write and keeps its old offset for the next open (measured); a pending section ask dies with the panel (round two, LOW 2 and 7)
   function openSettings(tab, section) {
-    if (!p.hidden) { if (knownTab(tab)) { selectTab(tab); showSection(section); return; } closeSettings(); return; }   // the opener toggles the modal; a named tab on an open panel switches to it, and to its section (T379)
+    if (!p.hidden) { if (knownTab(tab)) { selectTab(tab); if (section) showSection(section); else clearSectionScroll(); return; } closeSettings(); return; }   // the opener toggles the modal; a named tab on an open panel switches to it, and to its section (T379)
     selectTab(tab);
     // Signal the SHELL first, then measure (the picker's order, adopted 2026-08-09): feedFull posts
     // settings-open, which is what un-hides #feed-pane when the feed is toggled off — measuring first
     // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
     // full-viewport fallback box blacked out every pane behind the modal.
     try { if (window.parent !== window) window.parent.postMessage({ romp: 'logUnseenQuery' }, '*'); } catch (e) { /* no shell to ask */ }   // T290: the Open log count
-    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (sbg) sbg.checked = s.showSessionBadge === true; if (sr) sr.checked = s.stripGroupRows !== false; if (dn) dn.checked = s.denseChrome === true; if (fl) fl.value = s.fileLinkPane === 'pane' ? 'pane' : 'chat'; if (fsc) fsc.checked = (s.showFilesControl === true); (function (p) { Object.keys(pn).forEach(function (k) { if (pn[k]) pn[k].checked = p[k]; }); })(panesOf(s)); tcPaint(); paintWidgets(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) { bk.value = BN.effectiveDefaultBackend(s.backend); repaintSelectPicks(); } if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); showSection(section); }
+    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (sbg) sbg.checked = s.showSessionBadge === true; if (sr) sr.checked = s.stripGroupRows !== false; if (dn) dn.checked = s.denseChrome === true; if (fl) fl.value = s.fileLinkPane === 'pane' ? 'pane' : 'chat'; if (fsc) fsc.checked = (s.showFilesControl === true); (function (p) { Object.keys(pn).forEach(function (k) { if (pn[k]) pn[k].checked = p[k]; }); })(panesOf(s)); tcPaint(); paintWidgets(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) { bk.value = BN.effectiveDefaultBackend(s.backend); repaintSelectPicks(); } if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); if (section) showSection(section); else clearSectionScroll(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(typeof e.data.tab === 'string' ? e.data.tab : undefined, typeof e.data.section === 'string' ? e.data.section : undefined); });   // the tab and its section ride the ask (T379: the strip's gear opens Chat at Tab widgets)
   // Escape, relayed by the web shell's Escape chain (_LANDING_ESC_JS captures keydown in this same-origin

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -513,22 +513,24 @@ function initGear(post, opts) {
     try { localStorage.setItem(TAB_KEY, t); } catch (e) {}
     return t;
   }
-  Array.prototype.forEach.call(document.querySelectorAll('#rsettings .rs-tab'), function (b) { b.addEventListener('click', function (e) { e.stopPropagation(); selectTab(b.getAttribute('data-tab')); }); });
+  Array.prototype.forEach.call(document.querySelectorAll('#rsettings .rs-tab'), function (b) { b.addEventListener('click', function (e) { e.stopPropagation(); selectTab(b.getAttribute('data-tab')); clearSectionScroll(); }); });   // a pill change starts its pane at the top with no section room left behind (the follow-up's round one, LOW 1)
   // a SECTION of the tab (the user 2026-09-12): an ask may name a section of the tab it opens (data-section on the section's
   // head; the strip's tab-widgets gear asks for chat / tabwidgets), and the card scrolls so that head sits at its top, under
   // the padding. Looked up in the SHOWN pane only, after the panel is displayed (rects exist only then). Set on the card,
   // the modal's one scroll box, never scrollIntoView, which would scroll the host document too.
   // the one pending section ask (round two, LOW 2): an observer registered for an unlaid-out ask is disconnected on close and
   // before a new ask, so a later open never fires a stale scroll; a plain open (no section) resets the card (LOW 7)
-  var sectionRO = null;
+  var sectionRO = null, sectionAsk = null;
   function clearSectionScroll() {
     if (sectionRO) { sectionRO.disconnect(); sectionRO = null; }
+    sectionAsk = null;
     var card = document.querySelector('#rsettings .rs-card');
-    if (card) card.scrollTop = 0;
+    if (card) { card.scrollTop = 0; card.removeAttribute('data-section-landed'); }
     Array.prototype.forEach.call(document.querySelectorAll('#rsettings .rs-pane'), function (pn) { pn.style.paddingBottom = ''; });
   }
   function showSection(section) {
     if (sectionRO) { sectionRO.disconnect(); sectionRO = null; }
+    sectionAsk = null;
     if (typeof section !== 'string' || !section) return;
     var sec = document.querySelector('#rsettings .rs-pane:not([hidden]) .rs-sec[data-section="' + section + '"]');
     var card = document.querySelector('#rsettings .rs-card');
@@ -539,20 +541,42 @@ function initGear(post, opts) {
       var cs = getComputedStyle(card), padT = parseFloat(cs.paddingTop) || 0, padB = parseFloat(cs.paddingBottom) || 0;
       // room at the pane's END so the head can reach the top even when the section is the last thing in the pane (round two,
       // LOW 1: the scroll used to stop at the card's end with the head far below the padding): the pane grows by what is
-      // missing below the section, cleared on close or a plain open
-      var missing = (card.clientHeight - padT - padB) - (pane.getBoundingClientRect().bottom - sec.getBoundingClientRect().top);
+      // missing below the section, cleared on close, a plain open or a pill change. The room is sized to the card's CAP
+      // (max-height, 88vh, a content box), not its current height: below the cap the card is content-driven and grows
+      // under any room added, so the head stopped short on tall windows (152px off at 1200px, measured by the review);
+      // sized to the cap, the card lands exactly there in one pass, whatever the window. A second measurement after the
+      // write takes up rounding, or a cap the computed style did not resolve to pixels.
+      var below = function () { return pane.getBoundingClientRect().bottom - sec.getBoundingClientRect().top; };
+      var capH = parseFloat(cs.maxHeight);
+      var content = isFinite(capH) && capH > 0 ? capH : (card.clientHeight - padT - padB);
+      var missing = content - below();
       pane.style.paddingBottom = missing > 0 ? Math.ceil(missing) + 'px' : '';
+      var short = (card.clientHeight - padT - padB) - below();
+      if (short > 0) pane.style.paddingBottom = Math.ceil(Math.max(missing, 0) + short) + 'px';
       card.scrollTop = card.scrollTop + sec.getBoundingClientRect().top - card.getBoundingClientRect().top - padT;
+      ask.top = card.scrollTop;   // what this ask set: a scroll event landing elsewhere is the user's, and ends the ask
+      card.setAttribute('data-section-landed', section);   // the landing's mark: what a lab waits for before it measures (never a delay)
     };
-    if (card.clientHeight > 0) { go(); return; }   // laid out already: an open panel, or a host that never hides this document
-    // Not laid out yet: in the shell this document sits in an iframe that is display:none until the shell hears the
-    // settings-open message feedFull just posted, and a scroll set on a box with no size clamps to zero (the served lab
-    // measured 0 on the first open). The card gaining a size IS the event that says the panel is visible, so the
-    // scroll rides it, once. No timer: a frame or a delay would guess at the shell's round trip.
+    var ask = { top: -1 };
+    sectionAsk = ask;
+    if (card.clientHeight > 0) go();   // laid out already: an open panel, or a host that never hides this document
+    // The ask STANDS until the user scrolls, a pill changes the pane, or the panel closes: the scroll re-lands the head
+    // whenever the pane's or the card's size changes. Two reasons, both events, never timers: in the shell this document
+    // sits in an iframe that is display:none until the shell hears the settings-open message feedFull just posted, and
+    // a scroll set on a box with no size clamps to zero (the served lab measured 0 on the first open), so the card
+    // gaining a size is the first landing; and a layout that settles AFTER that first size (a web font arriving, a list
+    // filling) moves everything above the section, so the head slid off the top on a slow runner (CI, 2026-09-13: neither
+    // at the top nor at the end). Only a size change re-lands it, so a picker opening over the pane moves nothing.
     if (typeof ResizeObserver !== 'function') return;
-    sectionRO = new ResizeObserver(function () { if (card.clientHeight > 0) { if (sectionRO) { sectionRO.disconnect(); sectionRO = null; } go(); } });
+    sectionRO = new ResizeObserver(function () { if (sectionAsk === ask && card.clientHeight > 0) go(); });
     sectionRO.observe(card);
+    sectionRO.observe(pane);
   }
+  // the user's own scroll ends a standing section ask (a scroll event that lands where the ask put it is the ask's own)
+  (function () {
+    var card = document.querySelector('#rsettings .rs-card');
+    if (card) card.addEventListener('scroll', function () { if (sectionAsk && Math.abs(card.scrollTop - sectionAsk.top) > 1) { if (sectionRO) { sectionRO.disconnect(); sectionRO = null; } sectionAsk = null; } });
+  })();
 
   // ── THE WIDGET ROWS (T379) ── one per registered widget: the live demo (a miniature tab rendering the widget over a
   // synthetic status through the SAME render the strip uses), the name and what it does, the sliding switch, and the

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -571,8 +571,8 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 .tab-widgets-gear:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }
 /* Vertical context gauge right of the name (the user 2026-08-08): the statusline battery rotated
    upright — fills bottom-up with the context-used %, in the SAME global-colormap colour (fill set
-   inline by tabCtxGauge, render.ts), no % text. A faint track so an empty gauge still reads as
-   "gauge", not dirt. Toggled in gear → Chat ("Context gauge in tabs"), default on. */
+   inline by the context bar widget, tab-widgets.ts tabCtxGauge), no % text. A faint track so an empty gauge still reads as
+   "gauge", not dirt. The gear's Tab widgets section (the Context bar row) switches it and picks when it shows; on by default. */
 .tab-ctx { flex: 0 0 auto; position: relative; width: 4px; height: 13px; border-radius: 2px;
   overflow: hidden; background: rgba(255, 255, 255, 0.13); }
 .tab-ctx-fill { position: absolute; left: 0; right: 0; bottom: 0; border-radius: 2px; }

--- a/ui/webview/tab-widgets.test.ts
+++ b/ui/webview/tab-widgets.test.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
+const STRIP_CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 import type { WidgetStatus, TabWidgetPrefs } from "./tab-widgets";
 
 type El = { tag: string; className: string; textContent: string; title: string; attrs: Record<string, string>; children: El[]; style: Record<string, string>;
@@ -164,4 +165,9 @@ test("source: the strip and the gear draw from this ONE module; the dot rule has
   assert.equal((RENDER.match(/const dotCls = tabDotClass\(st\);/g) || []).length, 0, "render.ts no longer appends the dot itself");
   const GEAR = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "gear.js"), "utf8");
   assert.match(GEAR, /var TW = require\('\.\/tab-widgets\.ts'\);/, "the gear renders the rows' live demos from the same module");
+});
+
+test("ONE .tab-key rule in the strip's sheet: this side owns it, so a merge with the tab hot keys pull request's copy cannot leave two identical blocks silently", () => {
+  assert.equal((STRIP_CSS.match(/^\.tab-key \{/gm) || []).length, 1);
+  assert.match(STRIP_CSS, /^\.tab-key \{ flex: 0 0 auto; font: 600 calc\(0\.82em \/ 0\.92\) ui-monospace, SFMono-Regular, Menlo, monospace; color: var\(--dim\); border: 1px solid var\(--box-border\);/m, "the agreed rule text");
 });

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -36,7 +36,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "vscode": "^1.85.0"
+        "vscode": "^1.88.0"
       }
     },
     "node_modules/@codemirror/autocomplete": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -6,7 +6,7 @@
   "publisher": "romp",
   "private": true,
   "engines": {
-    "vscode": "^1.85.0"
+    "vscode": "^1.88.0"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
The seven lows from the tab widgets' second review round (pull request 1541), none blocking.

- **The section scroll reaches the top.** The gear's scroll to the Tab widgets section stopped at the card's scroll end with the head well below the padding, since the section is the last thing in the Chat pane. The pane now gains room at its end for what is missing below the section, so the head sits under the card's padding; the room is cleared on close or a plain open. The lab asserts the head's place exactly, with no escape leg.
- **One pending section ask.** A ResizeObserver registered for an ask on an unlaid-out panel lives in one slot: a new ask retires it, and closing the panel disconnects it, so a later open never fires a stale scroll.
- **A plain open resets the card.** An open that names no section scrolls the card to its top and clears the room, instead of inheriting the previous section scroll.
- **The declared VS Code floor is 1.88.** The widget rows' `grid-template-columns: subgrid` needs Chromium 117 and the stylesheet's `oklch(from …)` already needed 119; the extension declared 1.85 (Chromium 114). 1.88 (Electron 28, Chromium 120) is the first release that ships both; a test pins the reason.
- **The `.tab-ctx` comment** names the widget module's gauge builder and the Context bar row, not the deleted gear row and a render.ts function.
- **One `.tab-key` rule, pinned by count**, so a merge with the tab hot keys pull request's copy cannot leave two identical blocks silently.
- **The lab's strip assertions read something.** One session carries a context percentage (62), so the legacy scenes' strip-unchanged check and the switch test's live-bar check are no longer vacuous; the strip test reads the bar's place between the name and the keycap.
- **The inputs are read on the window** (the third review round): the card has no tabindex, so a key scroll after a click in it targets the body and a listener on the card never saw it; the ask stood and the next size change threw the user's scroll away. The wheel, key, touch and pointer inputs are read on the window with capture, the chat's way, scoped to the card by containment for a wheel, a touch or a press and by the card being the scroll focus for a key. The ask's own scroll writes go through one marked writer whose single echo the scroll handler consumes, so a landing inside the input window after a press is never read as the user's. The pointer hold latches only on the scrollbar gutter and clears on blur and visibility change, where Chromium sends no release to a page put behind another mid-press.
- **A landing's echo is the frame's move** (the fourth round): the room drop that the landing measures with clamps the card to the top and the landing writes it back, so the write ledger read a move the frame never rendered and no scroll event paid, and the user's first real scroll after every landing was taken for that echo. The mark is the frame's net move now, and a debt no event pays is forgiven two frames on. A field, for the key rule, is an element that consumes the scroll keys (a text-like input, a textarea, a select, a contenteditable); a checkbox, radio, button or range input is not, so a key after a click on a checkbox row counts. The gutter grab's offsets come from the padding box, so the innermost content pixel is no grab.

**Tests**
- `gear-tabs.test.ts`: the observer slot, the reset on close and plain open, the room at the pane's end, the engine floor. `tab-widgets.test.ts`: the `.tab-key` count. `tests/test_tab_widgets_browser.py`: the head under the padding on the first open and on a re-ask, a plain reopen at scroll zero (the stale observer never fires), the seeded percentage showing exactly when the older setting says so. Red against the merged main (fd6cf95e) through a detached worktree, per test.
- The third round in `tests/test_tab_widgets_browser.py`'s tall context: a click in the card then PageUp past the input window and a size change (the card stays where the key put it), the ask's own landing echo inside the input window after a press (the mark survives, a second size change re-lands), a gutter grab lost to blur and visibility change (the ask stands), a press on the card's padding (no hold). `gear-tabs.test.ts` pins the window listeners with capture, the key's scroll-focus rule, the gutter-only grab, the blur and visibility clearing, and the one marked scroll write. The fourth round adds the echo-debt road (a re-land, one evidenced scroll, a size change: the card stays where the wheel put it), the checkbox-focus key road (a real PageUp after the focus lands on a checkbox row) and the edge-press road, nudges the lost-release and padding roads twice, and pins the frame-move ledger, the field rule and the padding-box offsets.

Tier: fix
