### PR TITLE
The incident scan's leaf road needs a document that seeds the one-file walk, the memo's cursor is dropped at the flip, and the reference names the routine stale tick (T391 follow-up)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1560,7 +1560,10 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   whole at every boot). The
   counters: the memo's answers (`served`), the walks it took (`walked`), the
   walks over a memo the file's growth or rewrite retired (`stale`; a file
-  whose entry merely left memory and came back is walked, not stale) and the
+  whose entry merely left memory and came back is walked, not stale; a live
+  leaf or a growing anchor named in a scan ticks it once per judge pass, the
+  routine retirement by growth, so a rising count beside a growing file is
+  expected and only a rise with no growth is a surprise) and the
   walks whose memo could not be read or stored (`fallback`: a document state
   of the wrong shape, or no reader entry after the walk).
 - `stacks`: every thread's last six frames, keyed by the thread's ident and

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1557,13 +1557,16 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   resident instead, since the chain walk reads them at every pass; a leaf
   with no assembly document, one with no compaction boundary, takes the memo
   road too, since the leaf road's seeded walk had nothing to seed and read it
-  whole at every boot). The
+  whole at every boot, and so does every cleared or resume-forked session's
+  leaf, whose document is written over its lineage and cannot seed the
+  one-file walk). The
   counters: the memo's answers (`served`), the walks it took (`walked`), the
   walks over a memo the file's growth or rewrite retired (`stale`; a file
-  whose entry merely left memory and came back is walked, not stale; a live
-  leaf or a growing anchor named in a scan ticks it once per judge pass, the
-  routine retirement by growth, so a rising count beside a growing file is
-  expected and only a rise with no growth is a surprise) and the
+  whose entry merely left memory and came back is walked, not stale; a growing
+  file on the memo road, a live leaf without a seeding document or a growing
+  anchor named in a scan, ticks it once per judge pass, the routine retirement
+  by growth, so a rising count beside a growing file is expected and only a
+  rise with no growth is a surprise) and the
   walks whose memo could not be read or stored (`fallback`: a document state
   of the wrong shape, or no reader entry after the walk).
 - `stacks`: every thread's last six frames, keyed by the thread's ident and

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -933,6 +933,7 @@ def set_checkpoint_dir(fn):
     _CKPT_DIR_FN = fn
     with _CKPT_LOCK:
         _CKPT_PENDING.clear(); _CKPT_SEQ.clear(); _FOLD_DIRTY.clear(); _CKPT_DOC_FOLDS.clear(); _DROP_OWED.clear()
+        _RETIRED_FOLDS.clear()                            # a retirement never outlives a state rebind (round two, low 2)
         _CKPT_CYCLE["cap"] = _ckpt_cycle_default_cap(); _CKPT_CYCLE["spent"] = 0
 
 
@@ -1399,7 +1400,9 @@ def checkpoint_write(path, force=False):
     folds.update(_carry_forward_states(key, folds, base, count, size, mtime))   # the disk document's states for folds this process never ran
     with _CKPT_LOCK:
         retired = set(_RETIRED_FOLDS.get(key, ()))        # taken AFTER the cursor snapshot and the carry: a forget that raced the
-    omitted = {n for n in retired if folds.pop(n, None) is not None or n in retired}   #  snapshot still omits its fold here
+    for n in retired:                                     #  snapshot still omits its fold here; every name taken is honoured by
+        folds.pop(n, None)                                #  this write whether the fold was present to pop or already absent
+    omitted = retired
     cut = min([f["count"] for f in folds.values()] or [count])   # the document's cut: the LOWEST written cursor (T359), so the
     moved = None                                          #  next process's tail read holds every record a lagging fold has
     if cut < count and len(ent) >= 8 and ent[7]:          #  yet to step (its append), bounded by the records this entry holds
@@ -5020,7 +5023,8 @@ def asm_sidecar_refresh(leaf_path, doc):
         return False
     meta = cp.with_name(cp.name + ".meta")
     try:
-        d = json.loads(meta.read_text())
+        text = meta.read_bytes(); _count_read(str(meta), len(text))   # counted like the seeds read (round two, low 3)
+        d = json.loads(text.decode("utf-8"))
         if isinstance(d, dict) and isinstance(d.get("files"), list) and "linked" in d:
             return False
     except (OSError, ValueError):
@@ -5066,6 +5070,8 @@ def _retire_fold(path, name):
     key = str(path)
     with _CKPT_LOCK:
         _RETIRED_FOLDS.setdefault(key, set()).add(name)
+        while len(_RETIRED_FOLDS) > _DROP_OWED_MAX:       # bounded like the owed drops: the oldest path's retirement is let go
+            _RETIRED_FOLDS.pop(next(iter(_RETIRED_FOLDS)), None)
         _FOLD_DIRTY.add(key)
 
 
@@ -5077,8 +5083,13 @@ def rewound_memo_forget(path):
     restore reading that much more tail for every fold. Forgotten here, the next write omits the fold and the cut follows the
     live folds."""
     key = str(path)
-    _REWOUND_CACHE.pop(key, None)
-    _retire_fold(key, "rewoundUuids")                     # the write omits it even when the document still carries it
+    had = _REWOUND_CACHE.pop(key, None) is not None
+    with _CKPT_LOCK:
+        on_disk = "rewoundUuids" in (_CKPT_DOC_FOLDS.get(key) or {})   # the document as last read or written carries the fold
+    if had or on_disk:                                    # retire only at the FLIP, when there is something to retire: a leaf-road
+        _retire_fold(key, "rewoundUuids")                 #  pass over a clean path retires nothing and dirties nothing (round two:
+    #                                                        an unconditional retirement popped a memo stored later in the process
+    #                                                        out of the next document and kept every leaf-road path dirty forever)
 
 
 def asm_document_stands(leaf_path):

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -1397,6 +1397,9 @@ def checkpoint_write(path, force=False):
     if not folds and not force:
         return False
     folds.update(_carry_forward_states(key, folds, base, count, size, mtime))   # the disk document's states for folds this process never ran
+    with _CKPT_LOCK:
+        retired = set(_RETIRED_FOLDS.get(key, ()))        # taken AFTER the cursor snapshot and the carry: a forget that raced the
+    omitted = {n for n in retired if folds.pop(n, None) is not None or n in retired}   #  snapshot still omits its fold here
     cut = min([f["count"] for f in folds.values()] or [count])   # the document's cut: the LOWEST written cursor (T359), so the
     moved = None                                          #  next process's tail read holds every record a lagging fold has
     if cut < count and len(ent) >= 8 and ent[7]:          #  yet to step (its append), bounded by the records this entry holds
@@ -1439,8 +1442,14 @@ def checkpoint_write(path, force=False):
         _CKPT_SEQ[key] = seq
         _CKPT_STATS["writes"] += 1
         _CKPT_DOC_FOLDS[key] = _doc_fold_shapes(folds)
-        if left_out:
-            _FOLD_DIRTY.add(key)                          # a lagging fold has no cursor in this document yet
+        if omitted:                                       # the retirements this document honoured are done; any that arrived
+            rem = _RETIRED_FOLDS.get(key)                 #  after the check above stay, and keep the path dirty for the next write
+            if rem is not None:
+                rem -= omitted
+                if not rem:
+                    _RETIRED_FOLDS.pop(key, None)
+        if left_out or _RETIRED_FOLDS.get(key):
+            _FOLD_DIRTY.add(key)                          # a lagging fold has no cursor in this document yet, or a retirement owed
         else:
             _FOLD_DIRTY.discard(key)
     return True
@@ -4996,24 +5005,68 @@ _HYDRATED_CAP = _env_or("ROMP_HYDRATED_CAP_MB", max(1024 ** 3, _machine_memory_b
 _LAZY_KINDS = ("a", "u", "c", "o", "k", "b")   # atom kinds whose message is lazy; boundary and refusal atoms carry no message
 
 
+def _asm_sidecar(doc):
+    """The document's sidecar ({"av", "path", "files", "linked"}): what the boot sweep and asm_document_seeds read, a few bytes,
+    never the document. `linked` says resume-fork links joined the inputs (the load refuses a document on its links too)."""
+    return {"av": _ASM_CKPT_V, "path": doc["path"], "files": sorted(doc["files"]), "linked": bool(doc.get("links"))}
+
+
+def asm_sidecar_refresh(leaf_path, doc):
+    """Rewrite an OLDER sidecar (one without the inputs list) beside a document just restored, so the scan's predicate stops
+    degenerating to the one-file lineage test for a session that already carried a document (round one, low 2): a write of
+    a few bytes, the document untouched."""
+    cp = _asm_ckpt_file(leaf_path)
+    if cp is None:
+        return False
+    meta = cp.with_name(cp.name + ".meta")
+    try:
+        d = json.loads(meta.read_text())
+        if isinstance(d, dict) and isinstance(d.get("files"), list) and "linked" in d:
+            return False
+    except (OSError, ValueError):
+        pass
+    try:
+        mtmp = meta.with_name(meta.name + ".%d.tmp" % os.getpid())
+        mtmp.write_text(json.dumps(_asm_sidecar(doc)))
+        os.replace(mtmp, meta)
+        return True
+    except OSError:
+        return False
+
+
 def asm_document_seeds(leaf_path):
     """Whether the assembly document for `leaf_path` can SEED a one-file walk of the leaf: its inputs are the leaf alone. Read
     from the sidecar's `files` (a few bytes, never the document); a sidecar without the list (an older write) answers as
     asm_document_stands does, and the next write adds it. A cleared or resume-forked session's document is written over the
     leaf plus its lineage, so file_rewound's load refused it on the inputs comparison and the leaf was read whole at every
     process (T391 follow-up, round one, low 1): such a leaf takes the memo road."""
-    cp = _asm_ckpt_file(leaf_path)
-    if cp is None or not cp.exists():
+    if not asm_document_stands(leaf_path):
         return False
+    cp = _asm_ckpt_file(leaf_path)
     meta = cp.with_name(cp.name + ".meta")
     try:
-        d = json.loads(meta.read_text())
+        text = meta.read_bytes(); _count_read(str(meta), len(text))   # the one steady-state read this predicate adds: counted
+        d = json.loads(text.decode("utf-8"))
     except (OSError, ValueError):
         return True                                       # no readable sidecar: the document stands, its inputs unknown
     files = d.get("files") if isinstance(d, dict) else None
     if not isinstance(files, list):
         return True
-    return files == [Path(leaf_path).stem]
+    return files == [Path(leaf_path).stem] and not d.get("linked")   # the leaf alone, no resume links among the inputs
+
+
+_RETIRED_FOLDS = {}                # path -> {fold name}: folds a caller retired whose cursor may still sit in the on-disk document;
+#                                   checkpoint_write consults it AFTER its cursor snapshot and its carry, so the document omits them
+#                                   (T391 follow-up, round one, medium: the carry re-added the memo's cursor from the document)
+
+
+def _retire_fold(path, name):
+    """Retire fold `name` of `path` for the next write: the in-memory cursor goes now, and the write skips the name when it
+    carries the on-disk document's states forward, so the document omits the fold and the cut follows the live folds."""
+    key = str(path)
+    with _CKPT_LOCK:
+        _RETIRED_FOLDS.setdefault(key, set()).add(name)
+        _FOLD_DIRTY.add(key)
 
 
 def rewound_memo_forget(path):
@@ -5024,15 +5077,13 @@ def rewound_memo_forget(path):
     restore reading that much more tail for every fold. Forgotten here, the next write omits the fold and the cut follows the
     live folds."""
     key = str(path)
-    if _REWOUND_CACHE.pop(key, None) is not None:
-        with _CKPT_LOCK:
-            _FOLD_DIRTY.add(key)
+    _REWOUND_CACHE.pop(key, None)
+    _retire_fold(key, "rewoundUuids")                     # the write omits it even when the document still carries it
 
 
 def asm_document_stands(leaf_path):
     """Whether an assembly document file exists for `leaf_path` (a stat, no read; False with no checkpoint directory): the
-    judges' incident scan asks before taking the leaf road, whose seeded walk needs the document, and takes the memo road
-    for a leaf that has none (a leaf with no compaction boundary can never have one, and was read whole at every boot)."""
+    existence half of asm_document_seeds, the predicate the judges' incident scan asks before taking the leaf road."""
     cp = _asm_ckpt_file(leaf_path)
     return cp is not None and cp.exists()
 
@@ -5530,8 +5581,8 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None, reason
             os.replace(tmp, cp)
             meta = cp.with_name(cp.name + ".meta")            # {"av", "path"}: what the boot sweep reads, never the document
             mtmp = meta.with_name(meta.name + ".%d.tmp" % os.getpid())
-            mtmp.write_text(json.dumps({"av": _ASM_CKPT_V, "path": doc["path"], "files": sorted(doc["files"])}))   # the inputs'
-            #                                                                   fsids too: asm_document_seeds reads them, never the document
+            mtmp.write_text(json.dumps(_asm_sidecar(doc)))   # the inputs' fsids and whether resume links joined them: what
+            #                                                   asm_document_seeds reads, never the document
             os.replace(mtmp, meta)
         except OSError:
             return skip("write")
@@ -5838,6 +5889,7 @@ def _asm_restore(key, leaf_path, candidate_files, links, rompuuid, postal_index,
     doc = _asm_ckpt_load(leaf_path, rompuuid, sdk_human, candidate_files, links)
     if doc is None:
         return None
+    asm_sidecar_refresh(leaf_path, doc)                   # an older sidecar gains the inputs list here (round one, low 2)
     try:
         seed, landed = _seed_from_doc(doc)
         fsids = list(doc.get("fsids") or [])

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -4996,6 +4996,39 @@ _HYDRATED_CAP = _env_or("ROMP_HYDRATED_CAP_MB", max(1024 ** 3, _machine_memory_b
 _LAZY_KINDS = ("a", "u", "c", "o", "k", "b")   # atom kinds whose message is lazy; boundary and refusal atoms carry no message
 
 
+def asm_document_seeds(leaf_path):
+    """Whether the assembly document for `leaf_path` can SEED a one-file walk of the leaf: its inputs are the leaf alone. Read
+    from the sidecar's `files` (a few bytes, never the document); a sidecar without the list (an older write) answers as
+    asm_document_stands does, and the next write adds it. A cleared or resume-forked session's document is written over the
+    leaf plus its lineage, so file_rewound's load refused it on the inputs comparison and the leaf was read whole at every
+    process (T391 follow-up, round one, low 1): such a leaf takes the memo road."""
+    cp = _asm_ckpt_file(leaf_path)
+    if cp is None or not cp.exists():
+        return False
+    meta = cp.with_name(cp.name + ".meta")
+    try:
+        d = json.loads(meta.read_text())
+    except (OSError, ValueError):
+        return True                                       # no readable sidecar: the document stands, its inputs unknown
+    files = d.get("files") if isinstance(d, dict) else None
+    if not isinstance(files, list):
+        return True
+    return files == [Path(leaf_path).stem]
+
+
+def rewound_memo_forget(path):
+    """Drop the incident scan's memo cursor for `path` (T391 follow-up, round one, low 2): a leaf that took the memo road while it
+    had no assembly document carries a rewoundUuids cursor in its fold document; once its first compaction lands and the scan
+    flips to the leaf road for good, that cursor would never step again, and the checkpoint's cut, the minimum over the folds,
+    would drag behind it by up to the lag bound (about an eighth of the file) until growth passed it, every later boot's
+    restore reading that much more tail for every fold. Forgotten here, the next write omits the fold and the cut follows the
+    live folds."""
+    key = str(path)
+    if _REWOUND_CACHE.pop(key, None) is not None:
+        with _CKPT_LOCK:
+            _FOLD_DIRTY.add(key)
+
+
 def asm_document_stands(leaf_path):
     """Whether an assembly document file exists for `leaf_path` (a stat, no read; False with no checkpoint directory): the
     judges' incident scan asks before taking the leaf road, whose seeded walk needs the document, and takes the memo road
@@ -5497,7 +5530,8 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None, reason
             os.replace(tmp, cp)
             meta = cp.with_name(cp.name + ".meta")            # {"av", "path"}: what the boot sweep reads, never the document
             mtmp = meta.with_name(meta.name + ".%d.tmp" % os.getpid())
-            mtmp.write_text(json.dumps({"av": _ASM_CKPT_V, "path": doc["path"]}))
+            mtmp.write_text(json.dumps({"av": _ASM_CKPT_V, "path": doc["path"], "files": sorted(doc["files"])}))   # the inputs'
+            #                                                                   fsids too: asm_document_seeds reads them, never the document
             os.replace(mtmp, meta)
         except OSError:
             return skip("write")

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -6098,7 +6098,12 @@ def _per_file_rewound(fsid, files):
             # pre-cut verdicts and the tail read now instead of the whole file (T323 stage 4a). A non-empty
             # transcript that yields ZERO records raises OSError there (the incremental reader swallows a
             # permissions break into an empty list): a failed read, not an empty file, and it must count like one.
-            if fp == leaf and em.asm_document_stands(fp):   # the leaf road: the document's pre-cut verdicts and the tail read now
+            if fp == leaf and len(files) == 1 and em.asm_document_seeds(fp):   # the leaf road: the document's pre-cut verdicts
+                em.rewound_memo_forget(fp)                #  and the tail read now; a document written over a two-file lineage (a
+                #                                           /clear anchor beside, or a resume fork's from-file among its inputs)
+                #                                           cannot seed the one-file walk, and the leaf takes the memo road (round
+                #                                           one, low 1); the memo's cursor from the leaf's documentless days is
+                #                                           dropped at the flip so the checkpoint's cut follows the live folds (low 2)
                 out |= em.file_rewound(fp, rompuuid=fsid, sdk_human=_sdk_owned(fsid))
             else:                                         # a dead episode's frozen file, or a leaf with no assembly document (no
                 #                                           compaction boundary yet, or ever: its seeded walk had nothing to seed

--- a/tests/test_rewind_memo.py
+++ b/tests/test_rewind_memo.py
@@ -452,6 +452,50 @@ class RewoundMemo(Harness):
         em.asm_document_seeds(path)
         self.assertGreater(em.checkpoint_stats()["documentBytes"], before, "the sidecar read is counted under documentBytes")
 
+    def test_a_leaf_road_pass_over_a_clean_path_retires_nothing_and_leaves_no_work(self):
+        """Round two: the forget fired at EVERY leaf-road pass, so every leaf on the leaf road sat permanently dirty (the converge
+        pass's zero-cost gate never quiet) and a memo stored later in the process was popped out of the next document. A pass
+        over a path with no cursor and no rewoundUuids on disk retires nothing and dirties nothing."""
+        jd, fsid, path = self._own_leaf("clean", scenario="compaction_atom")
+        self.fresh_process()
+        tree = em.parse_session(path, rompuuid=fsid, name="impl", dir="/TESTDIR", candidate_files=[path], postal_log=[], now=NOW)
+        self.assertTrue(em.asm_checkpoint_write(path, fsid, tree=tree))
+        em.fold_records({}, path, list, lambda st, r: st, ckpt="cleanFold")
+        self.assertTrue(em.checkpoint_write(path)); self.assertFalse(em.checkpoint_has_work(), "clean after the write")
+        jd._per_file_rewound(fsid, [path])                                # the leaf road, twice, over an unchanged clean path
+        jd._per_file_rewound(fsid, [path])
+        self.assertFalse(em.checkpoint_has_work(), "no retirement pending, nothing dirty: %r" % sorted(em.checkpoint_dirty()))
+        self.assertNotIn(path, em._RETIRED_FOLDS)
+
+    def test_a_memo_stored_after_a_leaf_road_pass_survives_the_next_write(self):
+        """Round two, the verifier's probe D: after a leaf-road pass the path took the memo road (its lineage grew an anchor), the
+        memo was stored, and the still-pending retirement popped it out of the next document and discarded the dirty mark: the
+        next process read the file whole again. With the retirement fired only at a real flip, the memo reaches the disk."""
+        jd, fsid, path = self._own_leaf("survive", scenario="compaction_atom")
+        self.fresh_process()
+        tree = em.parse_session(path, rompuuid=fsid, name="impl", dir="/TESTDIR", candidate_files=[path], postal_log=[], now=NOW)
+        self.assertTrue(em.asm_checkpoint_write(path, fsid, tree=tree))
+        jd._per_file_rewound(fsid, [path])                                # the leaf road (no memo anywhere: nothing to retire)
+        anchor = Path(path).with_name(fsid + ".jsonl")                    # the session clears: the leaf's file becomes an anchor
+        self.assertEqual(str(anchor), path, "the leaf IS <fsid>.jsonl here; a second file makes the lineage two files")
+        leaf2 = Path(path).with_name("7a391000-2222-4333-8444-000000000388.jsonl")   # outside _own_leaf's sid range
+        leaf2.write_text(json.dumps(G.uline(NOW + 5, "after the clear", "u_after", None)) + "\n")
+        files = jd._judge_candidates(fsid, [str(leaf2)]); self.assertEqual(len(files), 2)
+        jd._per_file_rewound(fsid, files)                                 # the memo road for the anchor: the memo stored
+        self.assertIn(path, em._REWOUND_CACHE)
+        em.fold_records({}, path, list, lambda st, r: st, ckpt="surviveFold")
+        self.assertTrue(em.checkpoint_write(path))
+        em.checkpoint_write(str(leaf2))                                  # the new leaf's own fold document (its memo too)
+        d = json.loads(em._ckpt_file(path).read_text())
+        self.assertIn("rewoundUuids", d["folds"], "the memo reached the disk: %r" % sorted(d["folds"]))
+        self.fresh_process()
+        with em._JSONL_CACHE_LOCK:
+            em._RECORD_CACHE_STATS["wholeReads"] = {}
+        jd._per_file_rewound(fsid, files)
+        rows = {k: v["bytes"] for k, v in em.record_cache_stats()["wholeReads"].items() if k.endswith("<-_per_file_rewound")}
+        self.assertEqual(rows, {}, "the next process reads no whole file: %s" % em.record_cache_stats()["wholeReads"])
+        self.assertEqual(em.rewound_memo_stats()["served"], 2, "both files served: %s" % em.rewound_memo_stats())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rewind_memo.py
+++ b/tests/test_rewind_memo.py
@@ -407,6 +407,9 @@ class RewoundMemo(Harness):
         jd._per_file_rewound(fsid, [path])                                # the memo road: a cursor at the file's record count
         self.assertIn(path, em._REWOUND_CACHE)
         n0 = em._REWOUND_CACHE[path][0]
+        em.fold_records({}, path, list, lambda st, r: st, ckpt="flipFold")   # a live fold beside it, as the settle's folds are
+        self.assertTrue(em.checkpoint_write(path), "the settle's write while the leaf is documentless: the memo reaches the disk")
+        self.assertIn("rewoundUuids", json.loads(em._ckpt_file(path).read_text())["folds"])
         recs = G.SINGLE_FILE["rewind_off_path"][0]()
         more = compacting_variant(recs, "flip")[len(recs):]                # the first compaction lands, with turns after it
         with open(path, "a") as fh:
@@ -417,11 +420,37 @@ class RewoundMemo(Harness):
         self.assertTrue(em.asm_checkpoint_write(path, fsid, tree=tree), em.asm_checkpoint_stats())
         jd._per_file_rewound(fsid, [path])                                # the leaf road now
         self.assertNotIn(path, em._REWOUND_CACHE, "the memo's cursor dropped at the flip")
-        em.fold_records({}, path, list, lambda st, r: st, ckpt="flipFold")   # a live fold at the file's record count: what the
-        self.assertTrue(em.checkpoint_write(path), "the next write")          #  settle's folds are on a live leaf
+        em.fold_records({}, path, list, lambda st, r: st, ckpt="flipFold")   # the live fold steps to the file's record count
+        self.assertTrue(em.checkpoint_write(path), "the next write")
         d = json.loads(em._ckpt_file(path).read_text())
-        self.assertNotIn("rewoundUuids", d["folds"], "the next write omits the fold: %r" % sorted(d["folds"]))
-        self.assertGreater(d["count"], n0, "the cut follows the live folds past the old cursor: %d vs %d" % (d["count"], n0))
+        self.assertNotIn("rewoundUuids", d["folds"], "the next write omits the fold, though the document carried it: %r" % sorted(d["folds"]))
+        self.assertEqual(d["count"], d["folds"]["flipFold"]["count"], "the cut equals the live fold's count: %r" % d)
+        self.assertGreater(d["count"], n0, "past the old cursor: %d vs %d" % (d["count"], n0))
+        self.assertNotIn(path, em._RETIRED_FOLDS, "the retirement honoured is done")
+
+    def test_the_sidecar_says_whether_resume_links_joined_the_inputs_and_an_older_sidecar_is_refreshed(self):
+        """Round one, lows 1 and 2: the load refuses a document on its links too, so a one-file lineage whose document was written
+        with resume links among the inputs cannot seed either (`linked`); and a session that already carried a document kept
+        the old sidecar shape indefinitely, since the write skips a restored entry: the restore rewrites the sidecar alone."""
+        jd, fsid, path = self._own_leaf("linked", scenario="compaction_atom")
+        self.fresh_process()
+        tree = em.parse_session(path, rompuuid=fsid, name="impl", dir="/TESTDIR", candidate_files=[path], postal_log=[], now=NOW)
+        self.assertTrue(em.asm_checkpoint_write(path, fsid, tree=tree))
+        cp = em._asm_ckpt_file(path); meta = cp.with_name(cp.name + ".meta")
+        d = json.loads(meta.read_text()); self.assertEqual((d["files"], d["linked"]), ([fsid], False), "%r" % d)
+        self.assertTrue(em.asm_document_seeds(path))
+        d["linked"] = True; meta.write_text(json.dumps(d))
+        self.assertFalse(em.asm_document_seeds(path), "links among the inputs: the one-file walk cannot be seeded")
+        meta.write_text(json.dumps({"av": d["av"], "path": d["path"]}))          # an older sidecar, without the list
+        self.assertTrue(em.asm_document_seeds(path), "an older sidecar answers as the stat did")
+        before = em.checkpoint_stats()["documentBytes"]
+        self.fresh_process(); modes = []
+        em.parse_session(path, rompuuid=fsid, name="impl", dir="/TESTDIR", candidate_files=[path], postal_log=[], now=NOW, asm_mode_out=modes)
+        self.assertEqual(modes, ["restore"])
+        d2 = json.loads(meta.read_text())
+        self.assertEqual((d2.get("files"), d2.get("linked")), ([fsid], False), "the restore refreshed the older sidecar: %r" % d2)
+        em.asm_document_seeds(path)
+        self.assertGreater(em.checkpoint_stats()["documentBytes"], before, "the sidecar read is counted under documentBytes")
 
 
 if __name__ == "__main__":

--- a/tests/test_rewind_memo.py
+++ b/tests/test_rewind_memo.py
@@ -16,7 +16,7 @@ import unittest
 from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, HERE)
-from test_asm_checkpoint import em, G, SID, NOW, Harness, kernel_module   # noqa: E402  the harness and the golden builders
+from test_asm_checkpoint import em, G, SID, NOW, Harness, kernel_module, compacting_variant   # noqa: E402  the harness and the golden builders
 
 
 class RewoundMemo(Harness):
@@ -99,7 +99,7 @@ class RewoundMemo(Harness):
         src = inspect.getsource(jd._per_file_rewound)
         self.assertIn("em.file_rewound(fp, rompuuid=fsid", src, "the leaf: the document's pre-cut verdicts and the tail")
         self.assertIn("em.rewound_uuids(fp, drop=fp not in lineage and not _sdk_owned(fp.stem))", src, "a dead file: the memo, its entry dropped; a lineage file or a registered session's own file resident")
-        self.assertLess(src.index("if fp == leaf and em.asm_document_stands(fp):"), src.index("em.rewound_uuids(fp, drop="),
+        self.assertLess(src.index("if fp == leaf and len(files) == 1 and em.asm_document_seeds(fp):"), src.index("em.rewound_uuids(fp, drop="),
                         "the leaf road decided first, and only for a leaf with an assembly document")
 
     def test_an_over_cap_set_is_recorded_as_such_and_walked_again(self):
@@ -350,6 +350,78 @@ class RewoundMemo(Harness):
         self.assertEqual(fails, 0)
         self.assertEqual(calls, [fsid], "the leaf road, with the rompuuid: %r" % calls)
         self.assertEqual(em.rewound_memo_stats()["walked"], 0, "the memo not consulted for a documented leaf")
+
+    def test_a_documented_leaf_of_a_two_file_lineage_takes_the_memo_road(self):
+        """Round one, low 1: a cleared or resume-forked session's document is written over the leaf plus its anchor, so the leaf
+        road's load refused it on the inputs comparison and the leaf was read whole at every process, at the head and the base
+        alike. A two-file lineage takes the memo road: read whole once, served at the next process."""
+        jd = kernel_module().jd
+        fsid = "7a391000-2222-4333-8444-000000000399"
+        td = Path(tempfile.mkdtemp()); (td / "state").mkdir()
+        saved = jd.STATE; jd._rebind_state(td / "state")
+        saved_owner = jd._SDK_OWNER_FN; jd._SDK_OWNER_FN = None
+        def restore():
+            jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear(); jd._rebind_state(saved); shutil.rmtree(td, ignore_errors=True)
+            jd._SDK_OWNER_FN = saved_owner
+        self.addCleanup(restore)
+        anchor = td / (fsid + ".jsonl")                                  # the session's anchor: _judge_candidates adds it beside the leaf
+        anchor.write_text("".join(json.dumps(r) + "\n" for r in G.scenario_resume_lineage_fileA()))
+        leaf = td / (G.FSID_B + ".jsonl")                                # the leaf compacts: it has a document, written over both files
+        leaf.write_text("".join(json.dumps(r) + "\n" for r in compacting_variant(G.scenario_resume_lineage_fileB(), "lin")))
+        for f in (anchor, leaf):
+            old = time.time() - 600; os.utime(f, (old, old))
+        cands = [str(anchor), str(leaf)]
+        self.fresh_process()
+        tree = em.parse_session(str(leaf), rompuuid=fsid, name="impl", dir="/TESTDIR", candidate_files=cands, postal_log=[], now=NOW)
+        self.assertTrue(em.asm_checkpoint_write(str(leaf), fsid, tree=tree), em.asm_checkpoint_stats())
+        self.assertTrue(em.asm_document_stands(str(leaf)))
+        files = jd._judge_candidates(fsid, [str(leaf)]); self.assertEqual(len(files), 2)
+        self.fresh_process()
+        out, fails = jd._per_file_rewound(fsid, files)
+        self.assertEqual(fails, 0)
+        em.checkpoint_write(str(leaf)); em.checkpoint_write(str(anchor))   # the settle's and the dirty writer's fold documents
+        self.fresh_process()
+        with em._JSONL_CACHE_LOCK:
+            em._RECORD_CACHE_STATS["wholeReads"] = {}
+        out2, fails2 = jd._per_file_rewound(fsid, files)
+        self.assertEqual((fails2, out2), (0, out))
+        rows = {k: v["bytes"] for k, v in em.record_cache_stats()["wholeReads"].items() if k.endswith("<-_per_file_rewound")}
+        self.assertEqual(rows, {}, "no whole read of the leaf at the next process: %s" % em.record_cache_stats()["wholeReads"])
+        self.assertFalse(em.asm_document_seeds(str(leaf)), "a document over two files cannot seed the one-file walk")
+
+    def test_the_sidecar_names_the_documents_inputs_and_a_one_file_document_seeds(self):
+        jd, fsid, path = self._own_leaf("seeds", scenario="compaction_atom")
+        self.fresh_process()
+        tree = em.parse_session(path, rompuuid=fsid, name="impl", dir="/TESTDIR", candidate_files=[path], postal_log=[], now=NOW)
+        self.assertTrue(em.asm_checkpoint_write(path, fsid, tree=tree))
+        meta = json.loads(em._asm_ckpt_file(path).with_name(em._asm_ckpt_file(path).name + ".meta").read_text())
+        self.assertEqual(meta.get("files"), [fsid], "the sidecar carries the inputs' fsids: %r" % meta)
+        self.assertTrue(em.asm_document_seeds(path))
+
+    def test_the_flip_to_the_leaf_road_forgets_the_memo_so_the_cut_follows_the_live_folds(self):
+        """Round one, low 2: a documentless leaf carries a rewoundUuids cursor in its fold document; when its first compaction lands
+        the scan flips to the leaf road for good, the cursor never steps again, and the checkpoint's cut (the minimum over the
+        folds) drags behind it until growth passes it. The flip drops the memo's cursor and the next write's cut follows."""
+        jd, fsid, path = self._own_leaf("flip", scenario="rewind_off_path")
+        self.fresh_process()
+        jd._per_file_rewound(fsid, [path])                                # the memo road: a cursor at the file's record count
+        self.assertIn(path, em._REWOUND_CACHE)
+        n0 = em._REWOUND_CACHE[path][0]
+        recs = G.SINGLE_FILE["rewind_off_path"][0]()
+        more = compacting_variant(recs, "flip")[len(recs):]                # the first compaction lands, with turns after it
+        with open(path, "a") as fh:
+            for r in more:
+                fh.write(json.dumps(r) + "\n")
+        old = time.time() - 600; os.utime(path, (old, old))
+        tree = em.parse_session(path, rompuuid=fsid, name="impl", dir="/TESTDIR", candidate_files=[path], postal_log=[], now=NOW)
+        self.assertTrue(em.asm_checkpoint_write(path, fsid, tree=tree), em.asm_checkpoint_stats())
+        jd._per_file_rewound(fsid, [path])                                # the leaf road now
+        self.assertNotIn(path, em._REWOUND_CACHE, "the memo's cursor dropped at the flip")
+        em.fold_records({}, path, list, lambda st, r: st, ckpt="flipFold")   # a live fold at the file's record count: what the
+        self.assertTrue(em.checkpoint_write(path), "the next write")          #  settle's folds are on a live leaf
+        d = json.loads(em._ckpt_file(path).read_text())
+        self.assertNotIn("rewoundUuids", d["folds"], "the next write omits the fold: %r" % sorted(d["folds"]))
+        self.assertGreater(d["count"], n0, "the cut follows the live folds past the old cursor: %d vs %d" % (d["count"], n0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix tier: three review lows on the leaf-road change (the previous one), two with tests that fail before them.

**Low 1, a document that cannot seed.** The leaf road's gate was a stat of the document file, not a check that the document can seed a one-file walk. A cleared or resume-forked session's document is written over the leaf plus its lineage, so `file_rewound`'s load refused it on the inputs comparison and the leaf was read whole at every process, at the head and the base alike. The leaf road is taken only when the lineage is one file and the document's inputs are the leaf alone; the assembly document's sidecar now names the inputs' fsids (a few bytes, read instead of the document; an older sidecar without the list answers as the stat did, and the next write adds it), and every other leaf takes the memo road.

**Low 2, the frozen cursor.** A documentless leaf carried a `rewoundUuids` cursor in its fold document; when its first compaction landed the scan flipped to the leaf road for good, the cursor never stepped again, and the checkpoint's cut, the minimum over the folds, dragged behind it by up to the lag bound until growth passed it, every later boot's restore reading that much more tail for every fold. The scan drops the memo's cursor at the flip, so the next write omits the fold and the cut follows the live folds.

**Low 3.** The reference says what a rising `stale` count means: a live leaf or a growing anchor named in a scan ticks it once per judge pass, the routine retirement by growth, and only a rise with no growth is a surprise.

**Tests** (`tests/test_rewind_memo.py`, three added): a documented leaf of a two-file lineage is read whole once and served at the next process ("{'zero<-_per_file_rewound': 1771} != {}" at the base: read whole again); the sidecar carries the inputs and a one-file document seeds (`None != [fsid]` at the base); the flip drops the memo's cursor and the next write's cut follows the live folds (the cursor still held at the base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)