### PR TITLE
The parse's roads count on the perf block and the boot-health row, every tick job is a sub-stage of jobs, and the stage split's four review lows (T398, T397 follow-up)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1747,9 +1747,11 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   with `entries`, `bytes` and `off`); `chain` is the write-moment chain memo
   (`hit`, `miss`, `populate`, `bypass`); `nudgeGate` is the auto-nudge walk's
   planner-placement gate, derived once per (parse, store) and served while
-  both stand (`served`, `derived`, and `failed`: the derivations that raised
-  and waved nothing through, zero on a healthy box; a healthy quiet box serves
-  almost every cycle); `cleared` is the feed's clear set, parsed once per state of
+  both stand (`served`, `derived`, and `failed`: the derivations that raised;
+  the except leg answers NOT unplanned, so the walk skips the planner-queue
+  hold and proceeds on the closer gate alone, and a non-zero `failed` means
+  nudges were waved PAST the planner gate, not held; zero on a healthy box, and
+  a healthy quiet box serves almost every cycle); `cleared` is the feed's clear set, parsed once per state of
   `cleared.jsonl` (its stat, taken before the read) and served while the file
   stands (`served`, `derived`); `courierSkip` is the courier's change gate
   (`skipped`, `scanned`, `recorded`: a session whose parse, store, journal,

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1529,12 +1529,26 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   split); the `push` container carries its sub-stages' sums, the jobs before
   the push land in `jobs`, and the boundary sits at the push's entry, before
   the cards-first path. A plain GET carries the newest 16 splits and
-  `stageRingLen`; `GET /perf?ring=all` carries the whole ring, which holds
+  `stageRingLen` (how many splits the ring holds now, not how many were
+  served); `GET /perf?ring=all` carries the whole ring, which holds
   `stageRingMax` cycles: `ROMP_PERF_STAGE_RING` when set, else one per 64 MiB
   of the machine's memory floored at 16, resolved once, never a literal
-  count. The restart ledger's boot-health row carries the first cycle's
-  `stages` beside `firstCycleS`, so a slow boot names its stage without the
-  kernel alive.
+  count, and an override above the fraction is clamped to it. Under `jobs`
+  every tick job is a sub-stage (`jobs.<job>`, the glue between them
+  `jobs.other`), and `prelude` is the cycle's opening (the liveness snapshot,
+  the names), so the stages sum to `s`; `splitFailed` counts a split the
+  bookkeeping could not close. The restart ledger's boot-health row carries
+  the first cycle's `stages` beside `firstCycleS`, so a slow boot names its
+  stage without the kernel alive, and `parse`, the assembly's road counters at
+  the first cycle's end (T398): `serve`, `fold`, `restore`, `full` with
+  `full:demoted` (an entry the gates demoted, the `g:<reason>` beside it:
+  `rewrite` when the leaf's record entry was replaced by a from-zero read
+  under a new generation, `nonleaf` when a lineage file moved),
+  `full:noDocument`, `full:refused` (a document that stood but did not verify,
+  its fallback reason counted), `bypass` (a pending cut armed on the session)
+  and `fallback`; the same block rides `asmCheckpoint.parse` on GET /perf,
+  beside `asmCheckpoint.removed`, the document files removed per reason (a
+  fallback's reason, or the boot sweep).
 - `checkpoints`: the folds' checkpoints since boot: `restored` (files whose
   folds resumed from one), `restoredFolds` (restores per fold name), `writes`,
   `swept` (checkpoints of vanished files removed at boot), `refolds` (per fold

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1531,12 +1531,13 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   the cards-first path. A plain GET carries the newest 16 splits and
   `stageRingLen` (how many splits the ring holds now, not how many were
   served); `GET /perf?ring=all` carries the whole ring, which holds
-  `stageRingMax` cycles: `ROMP_PERF_STAGE_RING` when set, else one per 64 MiB
+  `stageRingMax` cycles: `ROMP_PERF_STAGE_RING` when set, else one per 256 MiB
   of the machine's memory floored at 16, resolved once, never a literal
   count, and an override above the fraction is clamped to it. Under `jobs`
-  every tick job is a sub-stage (`jobs.<job>`, the glue between them
-  `jobs.other`), and `prelude` is the cycle's opening (the liveness snapshot,
-  the names), so the stages sum to `s`; `splitFailed` counts a split the
+  every tick job is a sub-stage (`jobs.<job>`), and the bytes read between
+  them go to `jobs.other`, which carries bytes only, never `ms` (the same for
+  `push.other`); `prelude` is the cycle's opening (the liveness snapshot, the
+  names), so the top stages sum to `s`; `splitFailed` counts a split the
   bookkeeping could not close. The restart ledger's boot-health row carries
   the first cycle's `stages` beside `firstCycleS`, so a slow boot names its
   stage without the kernel alive, and `parse`, the assembly's road counters at
@@ -1665,10 +1666,14 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   (every hit). The acceptance number of the lazy-transcript work: a boot with
   no client connected reads `kernel` zero, and a connecting chat client adds
   at most its shown tabs.
-- `stages_ms`: `jobs` (the cycle's tick jobs outside the push), `push`, and
-  inside it `push.chat`, `push.feed`, `push.timeline`, `push.send`. The
-  `push.*` stages count every push, including the one a connecting page gets,
-  so they can add up to more than `push`.
+- `stages_ms`: `prelude` (the cycle's opening: the liveness snapshot and the
+  names), `jobs` (the cycle's tick jobs outside the push) and inside it one
+  `jobs.<job>` per tick job (`jobs.interruptBlock`, `jobs.autoNudge`,
+  `jobs.convergeCheckpoints` and the rest, T398), `push`, and inside it
+  `push.chat`, `push.feed`, `push.timeline`, `push.send`, `push.warm`,
+  `push.feedFirst`; a fresh snapshot lists every one at zero. The `push.*`
+  stages count every push, including the one a connecting page gets, so they
+  can add up to more than `push`.
 - `builds`: `chat`, `feed`, `timeline`, each with `cached`, `built`, `ms`.
   Every chat tab, the watched one included, is served from its cached build
   while one complete per-session signature holds: one component per input the

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -777,7 +777,7 @@ def read_bytes_report():
     file, so a test or /perf can say how much of a boot was tails and how much whole files."""
     with _READ_BYTES_LOCK:
         out = dict(_READ_BYTES)
-    out["total"] = sum(out.values())
+        out["total"] = _READ_BYTES_TOTAL[0]              # the running total, kept for this report alone (T397 round two, low 1)
     return out
 
 
@@ -1568,6 +1568,8 @@ def checkpoint_sweep():
         if not keep:
             try:
                 cp.unlink(); gone += 1
+                if cp.name.endswith(".gz"):
+                    _asm_removed("sweep")
                 if cp.name.endswith(".gz"):
                     cp.with_name(cp.name + ".meta").unlink(missing_ok=True)
             except OSError:
@@ -5048,6 +5050,7 @@ def _asm_ckpt_note(path, reason, detail=""):
     if cp is not None:
         try:
             cp.unlink()
+            _asm_removed("fallback:" + str(reason))
             cp.with_name(cp.name + ".meta").unlink(missing_ok=True)
         except OSError:
             pass
@@ -5062,9 +5065,17 @@ def _asm_ckpt_skip(reason):
 def asm_checkpoint_stats():
     with _ASM_CKPT_LOCK:
         out = dict(_ASM_CKPT_STATS); out["fallbacks"] = dict(out["fallbacks"]); out["skipped"] = dict(out["skipped"])
-        out["hydratedBy"] = dict(out["hydratedBy"])
+        out["hydratedBy"] = dict(out["hydratedBy"]); out["removed"] = dict(out.get("removed") or {})
         cv = out["converge"] = dict(out["converge"]); cv["skipped"] = dict(cv["skipped"])
-    return out
+    out["parse"] = dict(_ASM_STATS)                   # the parse's roads (T398): serve, fold, restore, full (with its reason), bypass,
+    return out                                        #  fallback, and every g:<reason> demotion, so a whole parse names its road
+
+
+def _asm_removed(reason):
+    """A document file removed, counted per reason (T398): the fallback that refused it, or the boot sweep."""
+    with _ASM_CKPT_LOCK:
+        r = _ASM_CKPT_STATS.setdefault("removed", {})
+        r[reason] = r.get(reason, 0) + 1
 
 
 def asm_converge_stat(name, n=1):
@@ -6055,8 +6066,20 @@ def _assemble(leaf_path, candidate_files, links, rompuuid, postal_index, sdk_hum
             elif _CKPT_DIR_FN is not None:
                 served = _asm_restore(key, leaf_path, candidate_files, links, rompuuid, postal_index, sdk_human)
                 if served is not None:
+                    _ASM_STATS["restore"] = _ASM_STATS.get("restore", 0) + 1
                     _mode("restore")
                     return served
+            # A full parse names its road (T398): an entry the gates DEMOTED (the g:<reason> beside it: the leaf's record
+            # entry replaced by a from-zero read, a lineage file moved), a leaf with NO document file, a document that
+            # stood but was REFUSED at the restore (its fallback reason counted beside), or no checkpoint directory at all.
+            if entry is not None:
+                why = "demoted"
+            elif _CKPT_DIR_FN is None:
+                why = "noDir"
+            else:
+                cp_ = _asm_ckpt_file(leaf_path)
+                why = "noDocument" if cp_ is None or not cp_.exists() else "refused"
+            _ASM_STATS["full:" + why] = _ASM_STATS.get("full:" + why, 0) + 1
             _mode("full")
             return _asm_full(key, leaf_path, candidate_files, links, rompuuid,
                              postal_index, sdk_human)

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -1568,9 +1568,8 @@ def checkpoint_sweep():
         if not keep:
             try:
                 cp.unlink(); gone += 1
-                if cp.name.endswith(".gz"):
+                if cp.name.endswith(".gz"):                # an assembly document: counted as removed, its sidecar with it
                     _asm_removed("sweep")
-                if cp.name.endswith(".gz"):
                     cp.with_name(cp.name + ".meta").unlink(missing_ok=True)
             except OSError:
                 pass
@@ -4413,7 +4412,8 @@ _ASM_CACHE_MAX = 256
 _ASM_LOCK = threading.Lock()       # guards the cache dict + the per-key lock registry only
 _ASM_KEYLOCKS = {}                 # key -> Lock; never pruned (a Lock is tiny, and swapping a
 #                                    key's lock mid-flight would let two folds interleave)
-_ASM_STATS = {"full": 0, "fold": 0, "serve": 0, "bypass": 0, "fallback": 0}   # observability + tests
+_ASM_STATS = {"full": 0, "fold": 0, "serve": 0, "restore": 0, "bypass": 0, "fallback": 0}   # observability + tests (restore
+#                                                                                             seeded: a row without it means zero)
 _ASM_WARNED = [False]
 _TS_REPAIR_NOTED = set()     # file stems already warned about a garbled stamp — once per file;
 #                              the cap CLEARS and re-arms (an occasional repeat note beats silence)
@@ -5036,11 +5036,17 @@ def _asm_ckpt_file(leaf_path):
     return Path(d) / (hashlib.sha1(os.path.realpath(str(leaf_path)).encode("utf-8")).hexdigest()[:20] + ".asm.json.gz")
 
 
+_ASM_CKPT_REFUSED = {}            # realpath -> the reason a standing document was refused at this path's last restore: read
+#                                   by _assemble to book full:refused, since the note below unlinks the document before the
+#                                   parse decides its road (T398 round one, medium: a refused document read as none at all)
+
+
 def _asm_ckpt_note(path, reason, detail=""):
     with _ASM_CKPT_LOCK:
         _ASM_CKPT_STATS["fallbacks"][reason] = _ASM_CKPT_STATS["fallbacks"].get(reason, 0) + 1
         first = (str(path), reason) not in _ASM_CKPT_SAID
         _ASM_CKPT_SAID.add((str(path), reason))
+        _ASM_CKPT_REFUSED[os.path.realpath(str(path))] = str(reason)
     if first:
         try:
             sys.stderr.write("assembly checkpoint fallback (%s) for %s%s\n" % (reason, path, (": " + detail) if detail else ""))
@@ -5067,7 +5073,8 @@ def asm_checkpoint_stats():
         out = dict(_ASM_CKPT_STATS); out["fallbacks"] = dict(out["fallbacks"]); out["skipped"] = dict(out["skipped"])
         out["hydratedBy"] = dict(out["hydratedBy"]); out["removed"] = dict(out.get("removed") or {})
         cv = out["converge"] = dict(out["converge"]); cv["skipped"] = dict(cv["skipped"])
-    out["parse"] = dict(_ASM_STATS)                   # the parse's roads (T398): serve, fold, restore, full (with its reason), bypass,
+    with _ASM_CKPT_LOCK:
+        out["parse"] = dict(_ASM_STATS)               # the parse's roads (T398): serve, fold, restore, full (with its reason), bypass,
     return out                                        #  fallback, and every g:<reason> demotion, so a whole parse names its road
 
 
@@ -6066,20 +6073,26 @@ def _assemble(leaf_path, candidate_files, links, rompuuid, postal_index, sdk_hum
             elif _CKPT_DIR_FN is not None:
                 served = _asm_restore(key, leaf_path, candidate_files, links, rompuuid, postal_index, sdk_human)
                 if served is not None:
-                    _ASM_STATS["restore"] = _ASM_STATS.get("restore", 0) + 1
+                    with _ASM_CKPT_LOCK:
+                        _ASM_STATS["restore"] += 1
                     _mode("restore")
                     return served
             # A full parse names its road (T398): an entry the gates DEMOTED (the g:<reason> beside it: the leaf's record
             # entry replaced by a from-zero read, a lineage file moved), a leaf with NO document file, a document that
             # stood but was REFUSED at the restore (its fallback reason counted beside), or no checkpoint directory at all.
+            with _ASM_CKPT_LOCK:
+                refused = _ASM_CKPT_REFUSED.pop(os.path.realpath(str(leaf_path)), None)   # the restore's own refusal, if any
             if entry is not None:
                 why = "demoted"
             elif _CKPT_DIR_FN is None:
                 why = "noDir"
-            else:
+            elif refused is not None:
+                why = "refused"                           # a document stood and did not verify (its reason under fallbacks); the
+            else:                                         #  note unlinked it, so the stat below would have read it as none
                 cp_ = _asm_ckpt_file(leaf_path)
                 why = "noDocument" if cp_ is None or not cp_.exists() else "refused"
-            _ASM_STATS["full:" + why] = _ASM_STATS.get("full:" + why, 0) + 1
+            with _ASM_CKPT_LOCK:
+                _ASM_STATS["full:" + why] = _ASM_STATS.get("full:" + why, 0) + 1
             _mode("full")
             return _asm_full(key, leaf_path, candidate_files, links, rompuuid,
                              postal_index, sdk_human)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -223,8 +223,9 @@ def _stage_ring_len(mem_total=None):
             n = int(raw) if raw else 0
         except ValueError:
             n = 0
-        _STAGE_RING_LEN[0] = n if n > 0 else max(16, _mem_total_bytes() // (64 * 1024 * 1024))
-    return _STAGE_RING_LEN[0]
+        frac = max(16, _mem_total_bytes() // (64 * 1024 * 1024))
+        _STAGE_RING_LEN[0] = min(n, frac) if n > 0 else frac   # the override never exceeds the fraction: a huge value made
+    return _STAGE_RING_LEN[0]                                    #  deque(maxlen=) raise inside cycle() (round two, low 2)
 
 
 class _PerfStats:
@@ -434,14 +435,17 @@ class _PerfStats:
             if ms > p["cycle_ms_max"]:
                 p["cycle_ms_max"] = ms
             self.ring.append(ms)
-            split = {"s": round(dt, 3), "t": time.time(),
-                     "stages": {k: {"ms": round(v["ms"], 1), "bytes": v["bytes"], "hydrated": v["hydrated"]}
-                                for k, v in self.cycle_stages.items()}}
-            if self.first_cycle is None:
-                self.first_cycle = split
-            if self.stage_ring is None:
-                self.stage_ring = collections.deque(maxlen=_stage_ring_len())
-            self.stage_ring.append(split)
+            try:                                          # the split's bookkeeping never ends the pusher thread (it runs in
+                split = {"s": round(dt, 3), "t": time.time(),   #  the cycle's finally, caught nowhere): a failure is counted
+                         "stages": {k: {"ms": round(v["ms"], 1), "bytes": v["bytes"], "hydrated": v["hydrated"]}
+                                    for k, v in self.cycle_stages.items()}}
+                if self.first_cycle is None:
+                    self.first_cycle = split
+                if self.stage_ring is None:
+                    self.stage_ring = collections.deque(maxlen=_stage_ring_len())
+                self.stage_ring.append(split)
+            except Exception:
+                p["splitFailed"] = p.get("splitFailed", 0) + 1
             self.cycle_stages = {}
             self._stage_mark = None
 
@@ -471,8 +475,8 @@ class _PerfStats:
                 return
             prev = self._stage_mark
             self._stage_mark = marks
-            if prev is not None:                            # the jobs before the push: to the cycle's `jobs` bucket
-                cs = self.cycle_stages.setdefault("jobs", {"ms": 0.0, "bytes": 0, "hydrated": 0})
+            if prev is not None:                            # bytes between the jobs' own stages: the glue, a sub-stage of jobs
+                cs = self.cycle_stages.setdefault("jobs.other", {"ms": 0.0, "bytes": 0, "hydrated": 0})
                 cs["bytes"] += max(0, marks[0] - prev[0]); cs["hydrated"] += max(0, marks[1] - prev[1])
 
     def stage(self, name, dt):
@@ -483,9 +487,14 @@ class _PerfStats:
                 return                                      # another thread's push: the totals alone
             cs = self.cycle_stages.setdefault(name, {"ms": 0.0, "bytes": 0, "hydrated": 0})
             cs["ms"] += dt * 1000.0
-            if name == "push":                              # the container: its bytes are its sub-stages' (already attributed)
-                cs["bytes"] = sum(v["bytes"] for k, v in self.cycle_stages.items() if k.startswith("push."))
-                cs["hydrated"] = sum(v["hydrated"] for k, v in self.cycle_stages.items() if k.startswith("push."))
+            if name in ("push", "jobs"):                    # a container: its bytes are its sub-stages' (already attributed),
+                prev = self._stage_mark                     #  the glue since the last sub-stage closed going to `<name>.other`
+                if prev is not None and (marks[0] > prev[0] or marks[1] > prev[1]):
+                    g = self.cycle_stages.setdefault(name + ".other", {"ms": 0.0, "bytes": 0, "hydrated": 0})
+                    g["bytes"] += max(0, marks[0] - prev[0]); g["hydrated"] += max(0, marks[1] - prev[1])
+                self._stage_mark = marks
+                cs["bytes"] = sum(v["bytes"] for k, v in self.cycle_stages.items() if k.startswith(name + "."))
+                cs["hydrated"] = sum(v["hydrated"] for k, v in self.cycle_stages.items() if k.startswith(name + "."))
             else:
                 prev = self._stage_mark
                 if prev is not None:
@@ -23343,6 +23352,10 @@ def _boot_health_first_cycle(dt):
     split = _PERF_STATS.first_cycle_split()                # T397: the cycle's stage split rides the row (the ledger reader
     if split is not None:                                  #  sees which stage a slow boot spent its time in without the kernel)
         row["stages"] = split.get("stages")
+    try:
+        row["parse"] = em.asm_checkpoint_stats().get("parse")   # T398: the parse's roads at the first cycle's end (serve, fold,
+    except Exception:                                           #  restore, full with its reason, bypass, the g:<reason> demotions)
+        pass
     if row["slow"]:
         try:
             sys.stderr.write("boot health: the first pusher cycle took %.1f s (bound %.0f s): sessions and cards waited behind it; "
@@ -49620,6 +49633,8 @@ def _pusher_cycle():
     few-hundred-ms staleness by construction — they always saw a snapshot aged by however many jobs
     ran before them."""
     _t_cycle = time.monotonic()
+    _PERF_STATS.cycle_begin()               # T397 round two, low 3: the split opens with the cycle, so the prelude below (the
+    #                                         liveness snapshot, the names) is a stage of its own and the stages sum to the wall
     _c_cycle = time.thread_time()           # this thread's CPU: the wall above includes lock waits and any forked child
     _m_cycle = (_PERF_STATS.marks(), jd._GOAL_IO["saves"], jd._GOAL_IO["writes"])   # idle-cycle marks: see cycle()
     with _clients_lock:
@@ -49643,6 +49658,7 @@ def _pusher_cycle():
         #                                       token and per postal card (~38% of pusher wall, py-spy
         #                                       2026-08-31). INSIDE the try: a raise here must still hit
         #                                       the finally, or the liveness scope above leaks set
+        _PERF_STATS.stage("prelude", time.monotonic() - _t_cycle)   # the cycle's opening: liveness, names, scopes (T397)
         _pusher_cycle_jobs(now, live_map, any_client)
     finally:
         _chat_push_scopes_close()
@@ -49657,16 +49673,28 @@ def _pusher_cycle():
         _boot_health_first_cycle(time.monotonic() - _t_cycle)   # the boot's first cycle, on the record (a no-op after)
 
 
+def _job_stage(name, thunk):
+    """One tick job as a sub-stage of `jobs` in the cycle's split (T398): the boot's first split said jobs 25 s with 224 MB read
+    and nothing finer, so each job here closes its own `jobs.<name>` stage and the row names the job that read. The job is a
+    thunk (`lambda: _x_tick(now, live_map)`), so the call reads as before on its line and the tests that pin those lines hold."""
+    _t = time.monotonic()
+    try:
+        return thunk()
+    finally:
+        _PERF_STATS.stage("jobs." + name, time.monotonic() - _t)
+
+
 def _pusher_cycle_jobs(now, live_map, any_client):
     _t_jobs = time.monotonic()            # /perf: this function minus the _push_all below is the `jobs` stage
-    _PERF_STATS.cycle_begin()             # T397: the cycle's first byte mark, so the split's bytes start here
+    if not _PERF_STATS._mine():
+        _PERF_STATS.cycle_begin()         # a caller that did not open the cycle (a test driving the jobs alone) opens it here
     try:                                  # the cycle's checkpoint byte budget, whole again, and the drops owed from the last one
-        _begin_checkpoint_cycle()         # (T362): before the builds below, whose quiescence drops write against it
+        _job_stage('beginCheckpointCycle', lambda: _begin_checkpoint_cycle())         # (T362): before the builds below, whose quiescence drops write against it
     except Exception:
         sys.stderr.write("checkpoint-cycle: %s\n" % traceback.format_exc())
     _t_push = 0.0
     try:                                  # parked ops deliver on the settle EVENT this cycle was woken for
-        _apply_pending_ops()              # (_wake_kernel, /tick, a park/cancel/move, the 0.5 s backstop) —
+        _job_stage('applyPendingOps', lambda: _apply_pending_ops())              # (_wake_kernel, /tick, a park/cancel/move, the 0.5 s backstop) —
         #                                   the parked-parse refresh runs inside, per sid, after the
         #                                   holds (2026-09-05)
     except Exception:                     # FIRST, so a delivered op's echo / retired chip rides this push;
@@ -49683,91 +49711,91 @@ def _pusher_cycle_jobs(now, live_map, any_client):
             _t_push = time.monotonic() - _t_push
             _PERF_STATS.stage("push", _t_push)
     try:                                  # the turn-finished push (bell popover): AFTER the feed build above,
-        _turn_notify_tick(now, live_map)      # so a bell event the same settle produced files its buzz first
+        _job_stage('turnNotify', lambda: _turn_notify_tick(now, live_map))      # so a bell event the same settle produced files its buzz first
     except Exception:
         sys.stderr.write("turn-notify: %s\n" % traceback.format_exc())
     # (the WS keepalive lives on its own _heartbeat thread — NOT here — so a slow push can't starve it)
     try:                                  # EXACT retraction first: dispatches returned → the stamp is spent,
-        _lift_spent_awaiting(now, live_map)   # so the nudge tick below never wakes a wait that already ended
+        _job_stage('liftSpentAwaiting', lambda: _lift_spent_awaiting(now, live_map))   # so the nudge tick below never wakes a wait that already ended
     except Exception:
         sys.stderr.write("awaiting-lift: %s\n" % traceback.format_exc())
     try:                                  # death is a recorded EVENT: a sid that left the live map is
-        _death_sweep_tick(now, live_map)      # corroborated with the liveness owner, then stamped (2026-08-13)
+        _job_stage('deathSweep', lambda: _death_sweep_tick(now, live_map))      # corroborated with the liveness owner, then stamped (2026-08-13)
     except Exception:
         sys.stderr.write("death-sweep: %s\n" % traceback.format_exc())
     try:                                  # a session that asked to close itself dies at its turn's settle
-        _end_on_idle_sweep(now, live_map)     # (the clean × path — the user 2026-08-15's "close yourself")
+        _job_stage('endOnIdle', lambda: _end_on_idle_sweep(now, live_map))     # (the clean × path — the user 2026-08-15's "close yourself")
     except Exception:
         sys.stderr.write("end-on-idle: %s\n" % traceback.format_exc())
     try:                                  # deferral records retire on their reasons' own events — BEFORE
-        _deferral_sweep_tick(now)         # the walk, independent of the nudge toggle (the stall/swirl
+        _job_stage('deferralSweep', lambda: _deferral_sweep_tick(now))         # the walk, independent of the nudge toggle (the stall/swirl
     except Exception:                     # surfaces read these records regardless)
         sys.stderr.write("deferral-sweep: %s\n" % traceback.format_exc())
     try:                                  # Auto Nudge runs server-side even with no browser open; the awaiting
-        _auto_nudge_tick(now, live_map)       # WAKE rides its goal walk (see _wake_goal) and runs even when the
+        _job_stage('autoNudge', lambda: _auto_nudge_tick(now, live_map))       # WAKE rides its goal walk (see _wake_goal) and runs even when the
     #                                       nudge is OFF — the toggle scopes the nudge legs, not the dead-man
     except Exception:
         sys.stderr.write("auto-nudge: %s\n" % traceback.format_exc())
     try:                                  # Interrupt → Blocked runs EVERY push, independent of the nudge toggle
-        _interrupt_block_tick(now, live_map)
+        _job_stage('interruptBlock', lambda: _interrupt_block_tick(now, live_map))
     except Exception:
         sys.stderr.write("interrupt-block: %s\n" % traceback.format_exc())
     try:                                  # the tick jobs' evaluation memo, persisted when a completed evaluation
-        _persist_tick_seen()              # moved it (T323 stage 1): the next kernel's first look starts from here
+        _job_stage('persistTickSeen', lambda: _persist_tick_seen())              # moved it (T323 stage 1): the next kernel's first look starts from here
     except Exception:
         sys.stderr.write("tick-seen: %s\n" % traceback.format_exc())
     try:                                  # the folds' checkpoints, written for a session at its settle or a states-log
-        _persist_checkpoints(now)         # move (T323 stage 3): the next kernel folds the tails, not the files
-        _converge_checkpoints(now)        # ...and the documents a boot's whole reads left dirty, bounded per cycle (T360)
+        _job_stage('persistCheckpoints', lambda: _persist_checkpoints(now))         # move (T323 stage 3): the next kernel folds the tails, not the files
+        _job_stage('convergeCheckpoints', lambda: _converge_checkpoints(now))        # ...and the documents a boot's whole reads left dirty, bounded per cycle (T360)
     except Exception:
         sys.stderr.write("checkpoints: %s\n" % traceback.format_exc())
     try:                                  # the boot row's backstop: written without attachDone once the bound has passed
-        _boot_row_backstop(now)
+        _job_stage('bootRowBackstop', lambda: _boot_row_backstop(now))
     except Exception:
         pass
     try:                                  # the kernel's own size at 5, 30 and 60 minutes and every hour (kernel-samples.jsonl)
-        _kernel_sample_tick(now)
+        _job_stage('kernelSample', lambda: _kernel_sample_tick(now))
     except Exception:
         pass
     try:                                  # hitting a usage limit auto-engages the retry-pause (before the resume check)
-        _auto_pause_on_limit()
+        _job_stage('autoPauseOnLimit', lambda: _auto_pause_on_limit())
     except Exception:
         sys.stderr.write("auto-pause-on-limit: %s\n" % traceback.format_exc())
     try:                                  # the login account's rate-limit meters, polled on a standing
-        _usage_poll_tick(now)             # interval (the user 2026-08-23): all-key traffic ends no login
+        _job_stage('usagePoll', lambda: _usage_poll_tick(now))             # interval (the user 2026-08-23): all-key traffic ends no login
     except Exception:                     # turns, so the turn-end refresh never fired and usage-history
         sys.stderr.write("usage-poll: %s\n" % traceback.format_exc())   # sat stale — blinding the judge
     #                                       quota gate and the headroom line
     try:                                  # a monthly spend cap (no readable reset) also engages it — else it storms forever
-        _auto_pause_on_spend_limit(now, live_map)
+        _job_stage('autoPauseOnSpend', lambda: _auto_pause_on_spend_limit(now, live_map))
     except Exception:
         sys.stderr.write("auto-pause-on-spend-limit: %s\n" % traceback.format_exc())
     try:                                  # the spend guard (T350): a session over the hourly ceiling is stopped and told,
-        _spend_guard_tick(now, live_map)      # every dashboard warned, a session-events row filed, once per crossing
+        _job_stage('spendGuard', lambda: _spend_guard_tick(now, live_map))      # every dashboard warned, a session-events row filed, once per crossing
     except Exception:
         sys.stderr.write("spend-guard: %s\n" % traceback.format_exc())
     try:                                  # a paused retry auto-clears once any session serves a request again
-        _auto_resume_retry(now, live_map)
+        _job_stage('autoResumeRetry', lambda: _auto_resume_retry(now, live_map))
     except Exception:
         sys.stderr.write("auto-resume-retry: %s\n" % traceback.format_exc())
     try:                                  # the bottom bar's API health cell: built AFTER this cycle's pause
-        _api_health_push(_api_health_frame(now, live_map))   # decisions, every cycle (a connecting shell gets a
+        _job_stage('apiHealth', lambda: _api_health_push(_api_health_frame(now, live_map)))   # decisions, every cycle (a connecting shell gets a
     except Exception:                     # current frame), sent only when it changed
         sys.stderr.write("api-health-frame: %s\n" % traceback.format_exc())
     try:                                  # a per-session interrupt-suppressed retry re-arms once that thread lands a clean turn
-        _auto_resume_session_retry(now, live_map)
+        _job_stage('autoResumeSession', lambda: _auto_resume_session_retry(now, live_map))
     except Exception:
         sys.stderr.write("auto-resume-session-retry: %s\n" % traceback.format_exc())
     try:                                  # the kernel drives the transient-api-error retry itself (unattended;
-        _auto_retry_tick(now, live_map)       # the dashboard tick is just the countdown + a redundant asker)
+        _job_stage('autoRetry', lambda: _auto_retry_tick(now, live_map))       # the dashboard tick is just the countdown + a redundant asker)
     except Exception:
         sys.stderr.write("auto-retry-tick: %s\n" % traceback.format_exc())
     try:                                  # self-scheduled wake signals queued in an idle SDK CLI get their
-        _idle_queue_drive_tick(now, live_map)  # turn driven (crons/monitors/task notices — see the tick)
+        _job_stage('idleQueueDrive', lambda: _idle_queue_drive_tick(now, live_map))  # turn driven (crons/monitors/task notices — see the tick)
     except Exception:
         sys.stderr.write("idle-queue-drive: %s\n" % traceback.format_exc())
     try:                                  # expire stale set_working notes once a session goes idle + done (cheap when no notes)
-        _clear_done_working_notes(now, live_map)
+        _job_stage('clearDoneNotes', lambda: _clear_done_working_notes(now, live_map))
     except Exception:
         sys.stderr.write("clear-working-notes: %s\n" % traceback.format_exc())
     _PERF_STATS.stage("jobs", (time.monotonic() - _t_jobs) - _t_push)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -209,13 +209,14 @@ _STAGE_RING_LEN = [None]          # resolved once (the first cycle), like the ot
 
 
 def _stage_ring_len(mem_total=None):
-    """How many cycles' stage splits the pusher keeps (T397): ROMP_PERF_STAGE_RING when it names a positive integer, else one
-    per 64 MiB of the machine's memory floored at 16 (a 64 GB box keeps 1024 cycles, a 4 GB one 64; an entry is about
-    2.5 KB, so the largest ring is a few MB), never a literal count (the user's caches direction 2026-09-11). Resolved ONCE
+    """How many cycles' stage splits the pusher keeps (T397): ROMP_PERF_STAGE_RING when it names a positive integer (clamped to
+    the fraction), else one per 256 MiB of the machine's memory floored at 16 (a 64 GB box keeps 256 cycles, a 4 GB one 16; an
+    entry carries about thirty stages at about 10 KB, so the largest ring is a few MB), never a literal count (the user's
+    caches direction 2026-09-11). Resolved ONCE
     into a module slot at first use (the memory reader is defined below this class and read again at every snapshot
     otherwise; round one, low 5). `mem_total` computes the fraction for a given reading (tests) and resolves nothing."""
     if mem_total is not None:
-        return max(16, int(mem_total) // (64 * 1024 * 1024))
+        return max(16, int(mem_total) // (256 * 1024 * 1024))
     if _STAGE_RING_LEN[0] is None:
         raw = os.environ.get("ROMP_PERF_STAGE_RING", "")
         n = 0
@@ -223,7 +224,7 @@ def _stage_ring_len(mem_total=None):
             n = int(raw) if raw else 0
         except ValueError:
             n = 0
-        frac = max(16, _mem_total_bytes() // (64 * 1024 * 1024))
+        frac = max(16, _mem_total_bytes() // (256 * 1024 * 1024))
         _STAGE_RING_LEN[0] = min(n, frac) if n > 0 else frac   # the override never exceeds the fraction: a huge value made
     return _STAGE_RING_LEN[0]                                    #  deque(maxlen=) raise inside cycle() (round two, low 2)
 
@@ -327,7 +328,12 @@ class _PerfStats:
     # below the table itself). test_perf_stats pins it at 1.5x the literal count.
     HTTP_PATHS = 256
     SLOTS = 32
-    STAGES = ("jobs", "push", "push.chat", "push.feed", "push.timeline", "push.send")
+    JOBS = ("beginCheckpointCycle", "applyPendingOps", "turnNotify", "liftSpentAwaiting", "deathSweep", "endOnIdle", "deferralSweep",
+            "autoNudge", "interruptBlock", "persistTickSeen", "persistCheckpoints", "convergeCheckpoints", "bootRowBackstop",
+            "kernelSample", "autoPauseOnLimit", "usagePoll", "autoPauseOnSpend", "spendGuard", "autoResumeRetry", "apiHealth",
+            "autoResumeSession", "autoRetry", "idleQueueDrive", "clearDoneNotes")   # the tick jobs, each a `jobs.<job>` stage (T398)
+    STAGES = ("prelude", "jobs", "push", "push.chat", "push.feed", "push.timeline", "push.send", "push.warm", "push.feedFirst") \
+        + tuple("jobs." + j for j in JOBS)   # every stage a fresh snapshot lists at zero: the cycle's prelude, the containers, the sub-stages
     BUILDS = ("chat", "feed", "timeline", "feedJson", "thread")
     # builds.chat's bg_miss labels: _chat_build_sig's components, a tab with no cached build, and a tab whose
     # signature could not be taken
@@ -344,7 +350,7 @@ class _PerfStats:
             self.pusher = {"cycles": 0, "wakes": 0, "wakes_event": 0, "wakes_backstop": 0,
                            "cycle_ms_sum": 0.0, "cycle_ms_max": 0.0, "cycle_ms_last": 0.0,
                            "cycle_cpu_ms_sum": 0.0, "sends": 0,
-                           "idle_cycles": 0, "idle_ms_sum": 0.0, "idle_cpu_ms_sum": 0.0}
+                           "idle_cycles": 0, "idle_ms_sum": 0.0, "idle_cpu_ms_sum": 0.0, "splitFailed": 0}
             self.ring = collections.deque(maxlen=self.RING)
             self.stages = {k: 0.0 for k in self.STAGES}
             # T397: the stage split PER CYCLE. `cycle_stages` fills as the cycle's stages close (wall ms, the reader's bytes

--- a/tests/test_assembly_road_counters.py
+++ b/tests/test_assembly_road_counters.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""T398 (2026-09-12): a boot parsed two documented live leaves whole with no fallback counted, and nothing on GET /perf named the
+road the parse took. The assembly's road counters (serve, fold, restore, full with its reason, bypass, the g:<reason> demotions)
+ride asmCheckpoint.parse and the boot-health row, beside asmCheckpoint.removed, the document files removed per reason."""
+import os
+import sys
+import unittest
+HERE = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, HERE)
+from test_asm_checkpoint import em, G, SID, NOW, Harness, kernel_module   # noqa: E402
+
+
+class AssemblyRoadCounters(Harness):
+    def _reset(self):
+        for k in list(em._ASM_STATS):
+            em._ASM_STATS[k] = 0
+
+    def test_the_roads_ride_the_perf_block_with_the_full_parses_reason(self):
+        records, sent = G.SINGLE_FILE["compaction_atom"]
+        path = self.write("roads", records(), sent=sent)
+        self.fresh(); self._reset()
+        self.parse(path)                                                  # no document yet: a full parse, its reason named
+        parse = em.asm_checkpoint_stats()["parse"]
+        self.assertEqual(parse.get("full:noDocument"), 1, "%s" % parse)
+        self.assertEqual(parse["full"], 1)
+        self.assertTrue(self.doc(path))
+        self.fresh(); self._reset()
+        self.parse(path)                                                  # the document restores
+        parse = em.asm_checkpoint_stats()["parse"]
+        self.assertEqual(parse.get("restore"), 1, "%s" % parse)
+        self.parse(path)                                                  # the same tree served from the entry
+        self.assertEqual(em.asm_checkpoint_stats()["parse"]["serve"], 1)
+        for k in ("serve", "fold", "full", "bypass", "fallback"):
+            self.assertIn(k, parse)
+
+    def test_a_from_zero_read_that_replaces_the_leafs_entry_demotes_and_is_counted_as_such(self):
+        """The cascade shape under study: an assembly entry stands, a whole reader replaces the leaf's record entry under a new
+        generation, and the next parse's gates demote the entry to a FULL parse that consults no document and counted nothing
+        anyone could see; now `g:rewrite` and `full:demoted` name it."""
+        records, sent = G.SINGLE_FILE["compaction_atom"]
+        path = self.write("demote", records(), sent=sent)
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
+        self.fresh(); self.parse(path); self._reset()                     # the entry stands, restored from the document
+        with em._JSONL_CACHE_LOCK:
+            em._JSONL_CACHE.pop(path, None)
+        em._read_jsonl_entry(path, tail_ok=False)                          # a from-zero read: a fresh generation
+        self.parse(path)
+        parse = em.asm_checkpoint_stats()["parse"]
+        self.assertEqual(parse.get("g:rewrite"), 1, "%s" % parse)
+        self.assertEqual(parse.get("full:demoted"), 1, "%s" % parse)
+
+    def test_a_removed_document_is_counted_per_reason(self):
+        records, sent = G.SINGLE_FILE["compaction_atom"]
+        path = self.write("removed", records(), sent=sent)
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
+        em._asm_ckpt_file(path).write_bytes(b"not a document")
+        em._ASM_CKPT_STATS["removed"] = {}
+        self.fresh(); self.parse(path)
+        st = em.asm_checkpoint_stats()
+        self.assertEqual(st["removed"], {"fallback:corrupt": 1}, "%s" % st["removed"])
+        self.assertFalse(em._asm_ckpt_file(path).exists())
+
+    def test_the_boot_health_row_carries_the_parses_roads(self):
+        km = kernel_module()
+        saved = (km._append_restart_cut, km._BOOT_HEALTH_DONE[0])
+        rows = []
+        km._append_restart_cut = lambda row: rows.append(row)
+        km._BOOT_HEALTH_DONE[0] = False
+        try:
+            km._boot_health_first_cycle(1.0)
+        finally:
+            km._append_restart_cut, km._BOOT_HEALTH_DONE[0] = saved
+        self.assertEqual(len(rows), 1)
+        self.assertIsInstance(rows[0].get("parse"), dict, "%r" % rows[0])
+        self.assertIn("full", rows[0]["parse"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_assembly_road_counters.py
+++ b/tests/test_assembly_road_counters.py
@@ -11,9 +11,27 @@ from test_asm_checkpoint import em, G, SID, NOW, Harness, kernel_module   # noqa
 
 
 class AssemblyRoadCounters(Harness):
+    def setUp(self):
+        super().setUp()
+        kernel_module()                                   # the kernel's first load refreshes the event model's globals: load it
+        #                                                   before any counter is read, so the row and the test see one dict
+
     def _reset(self):
         for k in list(em._ASM_STATS):
             em._ASM_STATS[k] = 0
+
+    def _boot_row_parse(self):
+        """The boot-health row's `parse` as the kernel writes it, over THIS test's event model (the kernel module holds its own
+        instance; the row reads whichever `em` the kernel names)."""
+        km = kernel_module()
+        saved = (km._append_restart_cut, km._BOOT_HEALTH_DONE[0], km.em); rows = []
+        km._append_restart_cut = lambda row: rows.append(row); km._BOOT_HEALTH_DONE[0] = False; km.em = em
+        try:
+            km._boot_health_first_cycle(1.0)
+        finally:
+            km._append_restart_cut, km._BOOT_HEALTH_DONE[0], km.em = saved
+        self.assertEqual(len(rows), 1)
+        return rows[0]["parse"]
 
     def test_the_roads_ride_the_perf_block_with_the_full_parses_reason(self):
         records, sent = G.SINGLE_FILE["compaction_atom"]
@@ -48,17 +66,25 @@ class AssemblyRoadCounters(Harness):
         parse = em.asm_checkpoint_stats()["parse"]
         self.assertEqual(parse.get("g:rewrite"), 1, "%s" % parse)
         self.assertEqual(parse.get("full:demoted"), 1, "%s" % parse)
+        row = self._boot_row_parse()
+        self.assertEqual((row.get("g:rewrite"), row.get("full:demoted")), (1, 1), "the boot row's values: %r" % row)
 
-    def test_a_removed_document_is_counted_per_reason(self):
+    def test_a_refused_standing_document_is_booked_as_refused_not_as_none(self):
+        """Round one, medium: the restore's refusal unlinked the document before _assemble decided the reason by a stat, so a
+        corrupt standing document was booked full:noDocument and a boot whose documents were all refused read as a boot that
+        had none. The refusal is recorded per path before the unlink and the parse books full:refused from it."""
         records, sent = G.SINGLE_FILE["compaction_atom"]
         path = self.write("removed", records(), sent=sent)
         self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
         em._asm_ckpt_file(path).write_bytes(b"not a document")
         em._ASM_CKPT_STATS["removed"] = {}
-        self.fresh(); self.parse(path)
+        self.fresh(); self._reset(); self.parse(path)
         st = em.asm_checkpoint_stats()
         self.assertEqual(st["removed"], {"fallback:corrupt": 1}, "%s" % st["removed"])
         self.assertFalse(em._asm_ckpt_file(path).exists())
+        self.assertEqual((st["parse"].get("full:refused"), st["parse"].get("full:noDocument", 0)), (1, 0),
+                         "a document that stood and did not verify: refused, not none: %s" % st["parse"])
+        self.assertEqual(self._boot_row_parse().get("full:refused"), 1, "the boot row carries it")
 
     def test_the_boot_health_row_carries_the_parses_roads(self):
         km = kernel_module()
@@ -72,7 +98,9 @@ class AssemblyRoadCounters(Harness):
             km._append_restart_cut, km._BOOT_HEALTH_DONE[0] = saved
         self.assertEqual(len(rows), 1)
         self.assertIsInstance(rows[0].get("parse"), dict, "%r" % rows[0])
-        self.assertIn("full", rows[0]["parse"])
+        for k in ("serve", "fold", "restore", "full", "bypass", "fallback"):
+            self.assertIn(k, rows[0]["parse"], "seeded keys: a row without one means zero: %r" % rows[0]["parse"])
+        self.assertEqual(rows[0]["parse"], em.asm_checkpoint_stats()["parse"], "the row is the perf block's parse, values and all")
 
 
 if __name__ == "__main__":

--- a/tests/test_boot_parse_gating.py
+++ b/tests/test_boot_parse_gating.py
@@ -274,7 +274,8 @@ class TickJobsKeyOnAChange(unittest.TestCase):
         self.assertNotIn("_tick_job_check", inspect.getsource(km._auto_nudge_session),
                          "the nudge has wall-clock timers, so it keeps its per-cycle evaluation (documented in _tick_job_check)")
         cyc = inspect.getsource(km._pusher_cycle_jobs)
-        self.assertLess(cyc.index("_interrupt_block_tick(now, live_map)"), cyc.index("_persist_tick_seen()"), "the memo is written after the tick jobs")
+        self.assertLess(cyc.index("_job_stage('interruptBlock', lambda: _interrupt_block_tick(now, live_map))"),
+                        cyc.index("_job_stage('persistTickSeen', lambda: _persist_tick_seen())"), "the memo is written after the tick jobs")
         self.assertIn("_persist_tick_seen(force=True)", inspect.getsource(km._drain_and_exit), "and at exit")
 
 

--- a/tests/test_first_cycle_stage_split.py
+++ b/tests/test_first_cycle_stage_split.py
@@ -74,7 +74,8 @@ class StageSplitUnit(unittest.TestCase):
         st = ps.snapshot()["pusher"]["firstCycle"]["stages"]
         self.assertEqual(st["push.chat"]["bytes"], 250)
         self.assertEqual(st["push"]["bytes"], 250, "the container carries its sub-stages' bytes")
-        self.assertEqual(st["jobs"]["bytes"], 1050, "the jobs before and after the push")
+        self.assertEqual(st["jobs.other"]["bytes"], 1050, "the jobs' glue before and after the push, a sub-stage of jobs")
+        self.assertEqual(st["jobs"]["bytes"], 1050, "the container carries its sub-stages' bytes")
 
     def test_the_split_is_the_pusher_threads_alone(self):
         """Round one, medium: a dashboard's connect push runs _push on the HTTP handler thread through the same stage calls; its
@@ -139,6 +140,43 @@ class StageSplitUnit(unittest.TestCase):
         src = inspect.getsource(km)
         self.assertIn('_PERF_STATS.snapshot(ring_all=(q.get("ring") or [""])[0] == "all")', src, "GET /perf?ring=all serves the ring")
 
+    def test_the_override_is_clamped_and_the_split_never_ends_the_pusher(self):
+        """Round two, low 2: an override above the fraction passed the positive check and deque(maxlen=) raised inside cycle(),
+        which runs in the pusher's finally and is caught nowhere, so a diagnostic knob ended the pusher thread for the
+        process's life. The override is clamped to the fraction, and the split's bookkeeping never raises (counted)."""
+        km = self.km
+        saved = km._STAGE_RING_LEN[0]
+        self.addCleanup(lambda: km._STAGE_RING_LEN.__setitem__(0, saved))
+        km._STAGE_RING_LEN[0] = None
+        with mock.patch.dict(os.environ, {"ROMP_PERF_STAGE_RING": str(2 ** 63 - 1)}):
+            self.assertEqual(km._stage_ring_len(), km._stage_ring_len(km._mem_total_bytes()), "clamped to the fraction")
+        ps = km._PerfStats()
+        real = km._stage_ring_len
+        km._stage_ring_len = lambda mem_total=None: 2 ** 70                 # a length the deque refuses
+        self.addCleanup(setattr, km, "_stage_ring_len", real)
+        ps.cycle_begin(); ps.stage("jobs", 0.001)
+        ps.cycle(0.002)                                                    # no raise
+        self.assertEqual(ps.snapshot()["pusher"].get("splitFailed"), 1)
+
+    def test_every_tick_job_is_a_sub_stage_and_the_report_total_is_the_counter(self):
+        """T398: the first live split said jobs 25 s with 224 MB read and nothing finer; every tick job closes its own
+        `jobs.<job>` stage, the container carries their sum. Round two, low 1: the report's total is the running counter."""
+        km = self.km
+        ps = km._PerfStats()
+        ps.cycle_begin()
+        em._count_read("/lab/tick.jsonl", 300)
+        ps.stage("jobs.interruptBlock", 0.004)
+        ps.stage("jobs.autoNudge", 0.001)
+        ps.stage("jobs", 0.006)
+        ps.cycle(0.007)
+        st = ps.snapshot()["pusher"]["firstCycle"]["stages"]
+        self.assertEqual(st["jobs.interruptBlock"]["bytes"], 300)
+        self.assertEqual(st["jobs"]["bytes"], 300, "the container carries its sub-stages' bytes")
+        self.assertIn("_job_stage('interruptBlock', lambda: _interrupt_block_tick(now, live_map))", inspect.getsource(km._pusher_cycle_jobs))
+        rep = em.read_bytes_report()
+        self.assertEqual(rep["total"], em.read_bytes_total())
+        self.assertGreaterEqual(rep["total"], sum(v for k, v in rep.items() if k != "total"))
+
 
 class LabBootFirstCycle(unittest.TestCase):
     """A lab boot whose first cycle runs at least two stages: the real pusher cycle with every tick job a no-op and the push a
@@ -172,12 +210,29 @@ class LabBootFirstCycle(unittest.TestCase):
         first = snap["firstCycle"]
         self.assertIsNotNone(first, "the first cycle's split is kept")
         self.assertTrue({"jobs", "push"} <= set(first["stages"]), "both stages named: %r" % sorted(first["stages"]))
+        self.assertTrue(any(k.startswith("jobs.") for k in first["stages"]), "the tick jobs as sub-stages: %r" % sorted(first["stages"]))
         self.assertGreaterEqual(first["stages"]["push"]["ms"], 5.0)
         self.assertLessEqual(sum(v["ms"] for k, v in first["stages"].items() if k in ("jobs", "push")), first["s"] * 1000.0 + 5.0,
                              "the stages fit the cycle's wall")
         self.assertEqual(len(self.rows), 1, "one boot-health row")
         self.assertEqual(sorted(self.rows[0]["stages"]), sorted(first["stages"]), "the row carries the split")
         self.assertEqual(self.rows[0]["firstCycleS"], round(dt, 2))
+
+
+    def test_a_whole_pusher_cycle_names_its_prelude_and_the_stages_sum_to_the_wall(self):
+        """Round two, low 3: cycle_begin was the jobs' first statement, so the liveness snapshot and the names before it had
+        no bucket and the stages under-summed the cycle. The cycle opens at the top of _pusher_cycle and the prelude is a
+        stage, so prelude + jobs + push fit the wall."""
+        km = self.km
+        km._push_all = lambda live_map=None: time.sleep(0.003)
+        km._pusher_cycle()
+        first = km._PERF_STATS.snapshot()["pusher"]["firstCycle"]
+        self.assertIsNotNone(first)
+        st = first["stages"]
+        self.assertIn("prelude", st, "%r" % sorted(st))
+        top = sum(v["ms"] for k, v in st.items() if k in ("prelude", "jobs", "push"))
+        self.assertLessEqual(top, first["s"] * 1000.0 + 2.0, "the top stages fit the wall: %r vs %r" % (top, first["s"]))
+        self.assertGreaterEqual(top, first["s"] * 1000.0 * 0.8, "and account for most of it: %r vs %r" % (top, first["s"]))
 
 
 if __name__ == "__main__":

--- a/tests/test_first_cycle_stage_split.py
+++ b/tests/test_first_cycle_stage_split.py
@@ -21,9 +21,9 @@ class StageSplitUnit(unittest.TestCase):
 
     def test_the_ring_is_a_fraction_of_memory_never_a_literal(self):
         km = self.km
-        self.assertEqual(km._stage_ring_len(64 * 1024 ** 3), 1024, "one cycle per 64 MiB: a 64 GB box keeps 1024")
-        self.assertEqual(km._stage_ring_len(4 * 1024 ** 3), 64)
-        self.assertEqual(km._stage_ring_len(512 * 1024 ** 2), 16, "the floor")
+        self.assertEqual(km._stage_ring_len(64 * 1024 ** 3), 256, "one cycle per 256 MiB: a 64 GB box keeps 256 (about 10 KB an entry)")
+        self.assertEqual(km._stage_ring_len(8 * 1024 ** 3), 32)
+        self.assertEqual(km._stage_ring_len(4 * 1024 ** 3), 16, "the floor")
         self.assertEqual(km._stage_ring_len(0), 16)
         self.assertGreaterEqual(km._stage_ring_len(), 16, "the machine's reading")
         # round one, low 5: resolved ONCE into a module slot, with an override
@@ -57,7 +57,12 @@ class StageSplitUnit(unittest.TestCase):
         self.assertEqual(snap["stageRing"][1]["stages"], {"jobs": {"ms": 1.0, "bytes": 0, "hydrated": 0}})
         self.assertEqual(snap["stageRingMax"], km._stage_ring_len())
         self.assertEqual(snap["stageRingLen"], 2)
-        self.assertIsNone(km._PerfStats().snapshot()["pusher"]["firstCycle"], "no cycle yet: no split")
+        fresh = km._PerfStats().snapshot()
+        self.assertIsNone(fresh["pusher"]["firstCycle"], "no cycle yet: no split")
+        self.assertEqual(fresh["pusher"]["splitFailed"], 0, "seeded at zero: a row without it means zero, not an older kernel")
+        self.assertEqual(fresh["stages_ms"]["prelude"], 0.0, "every stage listed at zero: %r" % sorted(fresh["stages_ms"])[:6])
+        self.assertIn("jobs.interruptBlock", fresh["stages_ms"])
+        self.assertEqual(len(km._PerfStats.JOBS), 24, "the 24 tick jobs by name")
 
     def test_a_stages_bytes_are_the_readers_bytes_since_the_previous_boundary(self):
         km = self.km
@@ -225,11 +230,15 @@ class LabBootFirstCycle(unittest.TestCase):
         stage, so prelude + jobs + push fit the wall."""
         km = self.km
         km._push_all = lambda live_map=None: time.sleep(0.003)
+        with km._clients_lock:                                             # a client, so the cycle pushes (any_client)
+            km._clients.append({"app": "feed", "wid": "lab", "send": lambda *a, **k: None, "alive": True})
+        self.addCleanup(lambda: [km._clients.remove(c) for c in list(km._clients) if c.get("wid") == "lab"])
         km._pusher_cycle()
         first = km._PERF_STATS.snapshot()["pusher"]["firstCycle"]
         self.assertIsNotNone(first)
         st = first["stages"]
         self.assertIn("prelude", st, "%r" % sorted(st))
+        self.assertGreaterEqual(st["push"]["ms"], 3.0, "the push ran (a client was connected): %r" % sorted(st))
         top = sum(v["ms"] for k, v in st.items() if k in ("prelude", "jobs", "push"))
         self.assertLessEqual(top, first["s"] * 1000.0 + 2.0, "the top stages fit the wall: %r vs %r" % (top, first["s"]))
         self.assertGreaterEqual(top, first["s"] * 1000.0 * 0.8, "and account for most of it: %r vs %r" % (top, first["s"]))

--- a/tests/test_kernel_deferral_sweep.py
+++ b/tests/test_kernel_deferral_sweep.py
@@ -194,7 +194,7 @@ class HardRuleAndRoutingPins(unittest.TestCase):
 
     def test_the_sweep_runs_every_tick_independent_of_the_toggle(self):
         src = inspect.getsource(km._pusher_cycle_jobs)
-        self.assertIn("_deferral_sweep_tick(now)", src)
+        self.assertIn("_job_stage('deferralSweep', lambda: _deferral_sweep_tick(now))", src)   # a tick job, its own stage (T398)
         sweep_pos = src.index("_deferral_sweep_tick")
         nudge_pos = src.index("_auto_nudge_tick")
         self.assertLess(sweep_pos, nudge_pos, "retirement runs before the walk that would re-fire")

--- a/tests/test_kernel_samples.py
+++ b/tests/test_kernel_samples.py
@@ -53,8 +53,9 @@ class KernelSamples(unittest.TestCase):
 
     def test_the_tick_rides_the_pusher(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
-        self.assertIn("        _kernel_sample_tick(now)\n", src)
-        self.assertLess(src.index("_boot_row_backstop(now)\n"), src.index("        _kernel_sample_tick(now)\n"), "beside the boot row's backstop in the tick jobs")
+        self.assertIn("        _job_stage('kernelSample', lambda: _kernel_sample_tick(now))\n", src)   # a tick job, its own stage (T398)
+        self.assertLess(src.index("_job_stage('bootRowBackstop', lambda: _boot_row_backstop(now))\n"),
+                        src.index("        _job_stage('kernelSample', lambda: _kernel_sample_tick(now))\n"), "beside the boot row's backstop in the tick jobs")
 
 
 class RestartPhasesScript(unittest.TestCase):

--- a/tests/test_planner_lazy_unit_text.py
+++ b/tests/test_planner_lazy_unit_text.py
@@ -165,18 +165,22 @@ class LazyUnitText(Harness):
                 break
         self.assertGreaterEqual(len(human), 2, "a golden scenario with two human segments")
         phantom, prompt = human[0], human[1]
-        real_plan, real_text = saved[0], saved[1]
+        real_text = saved[1]
         def stub_units(session, store=None, floor=jd._UNSET_FLOOR, lazy_text=False):
-            return [(phantom["id"], "work", phantom["t"], None, True, None, jd._seg_anchor(phantom), None),
+            # the phantom is a LIVE unit: its key carries the phase suffix (a work unit's key is the bare seg id, which a
+            # bare-seg-id write would also produce), so the assertion below tells the unit's own key from any other write
+            return [(phantom["id"], "live", phantom["t"], None, True, None, jd._seg_anchor(phantom), None),
                     (prompt["id"], "prompt", prompt["t"], jd._prompt_text(prompt["atoms"]), True, None, jd._seg_anchor(prompt), None)]
         jd.plan_units = stub_units
-        jd.unit_text_for = lambda seg, phase: "" if (seg["id"] == phantom["id"] and phase == "work") else real_text(seg, phase)
+        jd.unit_text_for = lambda seg, phase: "" if (seg["id"] == phantom["id"] and phase == "live") else real_text(seg, phase)
         calls = []
         jd.opener_llm = lambda text, menu_text, sibling_num=None: (calls.append(text), "")[1]   # a blank plan: the coerced place
         jd._plan_session(fsid, str(path), NOW)
         store = jd.load_goals(fsid)
-        pk, uk = jd._unit_key(phantom["id"], "work"), jd._unit_key(prompt["id"], "prompt")
+        pk, uk = jd._unit_key(phantom["id"], "live"), jd._unit_key(prompt["id"], "prompt")
+        self.assertNotEqual(pk, phantom["id"], "a suffixed key: distinguishable from a bare seg-id write")
         self.assertIn(pk, store["placements"]); self.assertIsNone(store["placements"][pk], "the phantom's OWN key retired")
+        self.assertNotIn(phantom["id"], store["placements"], "no bare seg-id write beside it")
         self.assertEqual(len(calls), 1, "the prompt unit reached the opener once: %r" % calls)
         self.assertIsNotNone(store["placements"].get(uk), "the prompt planned and placed: %r" % {k: v for k, v in store["placements"].items()})
 

--- a/tests/test_restart_phases.py
+++ b/tests/test_restart_phases.py
@@ -70,7 +70,7 @@ class BootMarks(unittest.TestCase):
 
     def test_the_backstop_rides_the_pusher_tick_not_a_thread(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
-        self.assertIn("        _boot_row_backstop(now)\n", src, "the pusher's tick jobs call it")
+        self.assertIn("        _job_stage('bootRowBackstop', lambda: _boot_row_backstop(now))\n", src, "the pusher's tick jobs call it (as its own stage, T398)")
         self.assertNotIn("threading.Timer(BOOT_ROW_BACKSTOP_S", src, "no timer thread: nothing outlives a boot (T282)")
         self.assertEqual(len(threading.enumerate()), len([t for t in threading.enumerate() if not t.name.startswith("boot-row")]))
 


### PR DESCRIPTION
Fix tier: diagnostics a boot read needed and could not get, plus four review lows on the stage split (the previous perf change); red-first per test at the base.

**T398, the parse's roads.** A boot parsed two documented live leaves whole with no fallback counted, and GET /perf did not carry the assembly's road counters. `asmCheckpoint.parse` now carries `serve`, `fold`, `restore`, `full` with its reason (`full:demoted` for an entry the gates demoted, the `g:<reason>` beside it: `rewrite` when the leaf's record entry was replaced by a from-zero read under a new generation, `nonleaf` when a lineage file moved; `full:noDocument`; `full:refused`; `full:noDir`), `bypass` (a pending cut) and `fallback`, and `asmCheckpoint.removed` counts the document files removed per reason (a fallback's reason, the boot sweep). The boot-health row carries `parse` beside `firstCycleS` and `stages`.

**A stage per tick job.** The first live split said `jobs` 25 s with 224 MB read and nothing finer. Every tick job in the pusher cycle closes its own `jobs.<job>` stage through a thunk (the call text stays literal on its line, so the tests that pin those lines hold); `jobs` and `push` are containers carrying their sub-stages' sums, the glue between sub-stages going to `<container>.other`.

**The stage split's lows.** The cycle opens at the top of the pusher cycle and the prelude (the liveness snapshot, the names) is a stage, so the top stages sum to the wall; the ring override is clamped to the memory fraction and the split's bookkeeping never raises (a failure counts under `splitFailed`), so a knob cannot end the pusher thread; the reader's report takes its total from the running counter; `stageRingLen` is glossed in the reference.

**Tests:** `tests/test_assembly_road_counters.py` (the roads on the perf block with the full parse's reason; a from-zero read that replaces the leaf's entry counted as `g:rewrite` and `full:demoted`; a removed document counted per reason; the boot-health row carrying the roads) and additions to `tests/test_first_cycle_stage_split.py` (the clamp and the never-raising split; every tick job a sub-stage and the report's total; the prelude and the stages summing to the wall; the containers' glue). At the base every new test fails: `KeyError: 'parse'`, `{} != {'fallback:corrupt': 1}`, the row without `parse`, `KeyError: 'jobs.other'`, the container's bytes 0, the override unclamped, `'prelude' not found`, no `jobs.` sub-stage. Four existing pins over tick-call lines re-derived to the thunk form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)