### PR TITLE
A hermetic kernel runs none of the update loop's three checks: the main-drift check raised the same banner on CI's clone of main

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7936,6 +7936,16 @@ def _consume_update_report(running_only=False, _tries=3):
     return rep
 
 
+def _update_checks_off():
+    """ROMP_UPDATE_CHECK=off: a HERMETIC kernel (a served lab's, tests/test_ship_reship.py kernel_env) runs none of the
+    update loop's three checks. The release check reads the release remote's tags, the main-drift check the remote's
+    main (git ls-remote, both), and either raises the shell's update banner over the page under test; the converge
+    check reads the checkout. CI 2026-09-13: the banner sat on the settings pills and took a lab's clicks, first from the
+    release check on a PR run, then from the drift check on main's own runs (a clone ON main, with main moving while the
+    job ran), so the seam stands the whole loop down before its first pass, and each check besides for a direct caller."""
+    return os.environ.get("ROMP_UPDATE_CHECK", "") == "off"
+
+
 def _update_check():
     """ONE check pass: learn the newest release, then act per mode. Runs at boot and then on
     _update_check_loop's cadence — kernels outlive browser tabs by days or weeks (the user
@@ -7943,10 +7953,7 @@ def _update_check():
     flipping the gear setting takes effect without a restart. A pass acts only when the discovered
     version CHANGES (new information): the same release re-found every few hours must not re-raise
     banners or re-file notices."""
-    if os.environ.get("ROMP_UPDATE_CHECK", "") == "off":
-        # a HERMETIC kernel (a served lab's, tests/test_ship_reship.py kernel_env): the check below reads the release
-        # remote's tags over the network, and a newer release than the checkout's raises the shell's update banner over
-        # the page under test (CI, 2026-09-13: the banner sat on the settings pills and took the lab's clicks)
+    if _update_checks_off():
         return
     if _update_mode() == "off":
         return
@@ -8317,6 +8324,8 @@ def _dist_converge_check():
     One rebuild attempt per distinct source state (the in-memory latch): a failure stays visible in its
     notice and on stderr, retries on the next source change or the next boot — never a 5-minute storm.
     The ROMP_DIST_DIR seam disables it: a redirected dist is the test's own to control."""
+    if _update_checks_off():
+        return                                        # a hermetic kernel: the loop's third check stands down with the other two
     if os.environ.get("ROMP_DIST_DIR"):
         return
     newest = _dist_src_newest()
@@ -8543,6 +8552,8 @@ def _main_drift_check():
     """One origin/checkout/running comparison pass; fires the SAME banner as the release check (the
     shell's offer() renders the main-drift wording off kind:"main"). Re-fires only when the target sha
     CHANGES — new information, never a re-nag of the sha already offered or dismissed."""
+    if _update_checks_off():
+        return                                        # a hermetic kernel: no ls-remote, no banner of this kind either
     if _update_mode() == "off":
         return
     if not _main_tracking():
@@ -8833,6 +8844,8 @@ def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV, target="
 def _update_check_loop():
     """The daemon thread: one pass at boot, then one per cadence, forever. The cheap main-drift probe
     runs every pass; the release-tag check keeps its six-hour stride."""
+    if _update_checks_off():
+        return                                        # a hermetic kernel: no pass at all (each check is gated besides)
     last_release = 0.0
     while True:
         try:

--- a/tests/test_update_check_hermetic.py
+++ b/tests/test_update_check_hermetic.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""A hermetic kernel never runs the update check (2026-09-13). The check reads the release remote's tags over the
+"""A hermetic kernel never runs the update loop's checks (2026-09-13). The check reads the release remote's tags over the
 network (git ls-remote), and when the checkout's release is older than the newest tag it raises the shell's update
 banner, a fixed alert at the top of the window. On CI that banner sat over the settings panel's pills and took every
 click of the tab widgets lab (main red at the tab widgets merge), while the same lab passed on a machine whose
@@ -54,6 +54,68 @@ class UpdateCheckSeam(unittest.TestCase):
     def test_without_the_seam_the_check_reads_the_release_remote_as_before(self):
         self.assertEqual(self._run_check(None), [True], "the control: the read happens (and its failure is swallowed loudly)")
         self.assertEqual(self._run_check("on"), [True], "only the literal off stands it down")
+
+
+class DriftCheckSeam(unittest.TestCase):
+    """The main-drift check fires the SAME banner (kind main) whenever the release remote's main is ahead of the checkout
+    or the running kernel, and CI's clone is ON main with main moving while a job runs (2026-09-13: the first main run
+    carrying the release-check seam was red on the same intercept). Under the seam it reads nothing and sends nothing."""
+
+    def _run_drift(self, env_value):
+        asked, sent = [], []
+
+        def origin():
+            asked.append(True)
+            return "cccc3333"
+        env = dict(os.environ)
+        env.pop("ROMP_UPDATE_CHECK", None)
+        if env_value is not None:
+            env["ROMP_UPDATE_CHECK"] = env_value
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch.object(km, "_update_mode", return_value="ask"), \
+             mock.patch.object(km, "_main_tracking", return_value=True), \
+             mock.patch.object(km, "_checkout_sha", return_value="aaaa1111"), \
+             mock.patch.object(km, "_kernel_sha", return_value="aaaa1111"), \
+             mock.patch.object(km, "_origin_main_sha", origin), \
+             mock.patch.object(km, "_send_to_app", lambda *a, **k: sent.append(a)):
+            km._main_drift_check()
+        return asked, sent
+
+    def test_off_stands_the_drift_check_down_before_the_remote_is_read_and_nothing_is_sent(self):
+        asked, sent = self._run_drift("off")
+        self.assertEqual((asked, sent), ([], []), "no ls-remote, no banner of the main kind")
+
+    def test_without_the_seam_the_drift_check_reads_the_remotes_main_as_before(self):
+        asked, _sent = self._run_drift(None)
+        self.assertEqual(asked, [True], "the control: the remote's main is read")
+
+
+class LoopSeam(unittest.TestCase):
+    """The daemon loop runs three checks a pass; under the seam it returns before the first pass."""
+
+    def _run_loop(self, env_value):
+        calls = []
+        env = dict(os.environ)
+        env.pop("ROMP_UPDATE_CHECK", None)
+        if env_value is not None:
+            env["ROMP_UPDATE_CHECK"] = env_value
+
+        class Stop:
+            def wait(self, _s):
+                return True   # one pass, then the loop's own exit
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch.object(km, "_update_check", lambda: calls.append("release")), \
+             mock.patch.object(km, "_dist_converge_check", lambda: calls.append("converge")), \
+             mock.patch.object(km, "_main_drift_check", lambda: calls.append("drift")), \
+             mock.patch.object(km, "_CHECK_LOOP_STOP", Stop()):
+            km._update_check_loop()
+        return calls
+
+    def test_off_runs_none_of_the_three_checks(self):
+        self.assertEqual(self._run_loop("off"), [], "no pass at all")
+
+    def test_without_the_seam_one_pass_runs_all_three(self):
+        self.assertEqual(self._run_loop(None), ["release", "converge", "drift"])
 
 
 class LabKernelsRunWithIt(unittest.TestCase):


### PR DESCRIPTION
The first main run carrying the update-check seam (1551) was red on the same intercept: the shell's update banner over the settings pills, six tab widgets lab tests. The seam gated only the release-tag check, but the kernel's update loop runs **three** checks a pass, and the main-drift check fires the same banner (kind main) whenever the release remote's main is ahead of the checkout or the running kernel; its audience gate reads the checkout's branch, and CI's clone is on main with main moving while the job runs, so the drift probe saw main ahead and raised the banner. A pull request's checkout is detached at the merge ref, which is why the PR run passed.

- **Under `ROMP_UPDATE_CHECK=off` the whole loop stands down** before its first pass, and each of the three checks (release tags, main drift, dist converge) is gated besides for a direct caller; the seam's comment names all three, not the release tags alone.
- **Tests** (`tests/test_update_check_hermetic.py`): under the seam the drift check reads no remote main and sends nothing (red at the base: the remote is read); the loop body runs none of the three (red at the base: all three run); the controls without the seam read and run as before.

No lab on this machine shows the shape (this checkout is not on main); the proof is main's next extension job after the merge.

Tier: fix
