### PR TITLE
The background box's header counts the peer row as a peer and names the sub-rows it leaves out; the two doc comments say what the header now does (T394 follow-up)

### DIFF
--- a/tests/test_bg_kinds_browser.py
+++ b/tests/test_bg_kinds_browser.py
@@ -96,12 +96,19 @@ const placedKept = await settle({ type: "status", id: f0.id, status: { ...f0.sta
 const doneOnly = await settle(only([task(cfg.doneId)], [], "idle"));
 // the one-kind idle wait with tracked rows beyond it (round three, low 3): waiting on one command, a kept service and a finished
 // command listed too; every listed row counted, the kept subset after
+// round four: the peer-named idle header counts the peer row as a peer beside the tracked rows; an agent's own wait is a sub-row the
+// header never counts (the session waits on the agent, the agent on it)
+const peerIdle = await settle({ ...f0, status: { ...f0.status, state: "idle", awaitingWhy: "delegated to api; waiting on a reply", awaitingKind: "peer", awaitingCount: 1,
+                                                 awaitingPeers: [{ name: "api", host: "", color: null }], awaitingItems: [{ kind: "peer", id: "api", label: "api" }], awaitingTaskIds: [], bgServiceIds: [cfg.svcId] },
+                                bgTasks: { count: 1, tasks: [task(cfg.svcId)] } });
+const nested = await settle({ ...f0, status: { ...f0.status, state: "working", awaitingItems: [{ ...f0.status.awaitingItems.find((it) => it.kind === "agents"), waits: [{ kind: "commands", id: cfg.placedId, label: "Run the parser test chunk", stoppable: true }] }], awaitingTaskIds: [], bgServiceIds: [] },
+                              bgTasks: { count: 2, tasks: [task("tu_agent_1"), task(cfg.placedId)] } });
 const idleOne = await settle({ ...f0, status: { ...f0.status, state: "idle", awaitingWhy: "waiting on a background command: Build the docs site", awaitingKind: "commands", awaitingCount: 1,
                                                awaitingItems: f0.status.awaitingItems.filter((it) => it.kind === "commands"), awaitingTaskIds: [cfg.cmdId], bgServiceIds: [cfg.svcId, cfg.doneId] },
                                 bgTasks: { count: 3, tasks: [task(cfg.cmdId), task(cfg.svcId), task(cfg.doneId)] } });
 if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_chat-T394-bg-kinds-light-served.png" }); }
 await browser.close();
-process.stdout.write("RESULT:" + JSON.stringify({ dark, light, placedOnly, placedKept, doneOnly, idleOne }) + "\n", () => process.exit(0));
+process.stdout.write("RESULT:" + JSON.stringify({ dark, light, placedOnly, placedKept, doneOnly, idleOne, peerIdle, nested }) + "\n", () => process.exit(0));
 """
 
 
@@ -311,6 +318,19 @@ class ServedBgKinds(unittest.TestCase):
         self.assertEqual([(x["label"], x["kept"]) for x in io["rows"]], [("Build the docs site", None), ("Serve the docs preview", KEPT_WORD), ("Warm the docs cache", None)], "the wait's row, the kept service, the finished command: %r" % io["rows"])
         self.assertEqual(io["header"], "Awaiting command · a background command: Build the docs site · 3 commands · 1 kept running",
                          "the wait's word and sentence, then every listed row by kind, then the kept subset: %r" % io["header"])
+
+    def test_the_peer_named_idle_header_counts_the_peer_row_as_a_peer_and_an_agents_own_wait_stays_a_sub_row(self):
+        # round four: the rule's sentence made true for every branch. A session idle on a delegated peer with a kept service listed
+        # counts the peer row as a peer; an awaited agent's own wait is drawn as a sub-row under it and the header never counts it
+        r = self._result()
+        pi = r["peerIdle"]
+        # the sections in the rows' display order (agents, commands, watches, peers, timers): the kept service, then the peer
+        self.assertEqual([(x["section"], x["label"], x["kept"]) for x in pi["rows"]], [("Commands", "Serve the docs preview", KEPT_WORD), ("Peers", "api", None)], "the kept service and the peer row: %r" % pi["rows"])
+        self.assertTrue(pi["header"].startswith("Awaiting api"), "the wait names the peer: %r" % pi["header"])
+        self.assertTrue(pi["header"].endswith(" · 1 command · 1 peer · 1 kept running"), "…then every listed row by kind, the peer as a peer, and the kept subset: %r" % pi["header"])
+        ne = r["nested"]
+        self.assertEqual([(x["label"], "bg-sub" in x["cls"].split()) for x in ne["rows"]], [("Map the notes-api parser", False), ("Run the parser test chunk", True)], "the agent, then its own wait as a sub-row: %r" % ne["rows"])
+        self.assertEqual(ne["header"], "In the background · 1 agent", "the header counts the top level only: the sub-row is the agent's: %r" % ne["header"])
 
     def test_a_completed_only_box_wears_the_dim_ink_on_its_header_dot(self):
         # round two, low 2: the worst status seeds from the tasks, so a completed-only box reads completed, the dim ink, not the running gold

--- a/ui/webview/awaiting-rows.test.ts
+++ b/ui/webview/awaiting-rows.test.ts
@@ -148,7 +148,7 @@ test("the box groups the rows by kind, headers only when more than one group sho
   // the rows were there): each lists in its KIND's section, after the awaited rows, dimmed, the judge's verdict as a suffix
   assert.doesNotMatch(RENDER, /BG_LEFTOVER_TITLE|"Also running"|"Background tasks"/, "no section of its own, under either of its old names");
   assert.match(body, /for \(const row of kept\) if \(row\.kind === g\.kind\) list\.appendChild\(bgRow\(row, sid\)\);/);
-  // the header: mixed → "Awaiting <n> · <breakdown>" counting the kept rows apart; one kind → the sentence as before, the kept count after it
+  // the header: mixed → "Awaiting <n> · <breakdown of every listed row, then the kept subset>"; one kind → the sentence as before, the kept count after it
   assert.match(body, /\} else if \(groups\.length > 1\) \{\s*\n\s*lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(counted, keptN\);/);
   assert.match(body, /lab\.textContent = "Awaiting" \+ \(word \? " " \+ word : ""\) \+ " · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\) \+ \(kept\.length \? " · " \+ listBreakdown\(counted, keptN\) : ""\);/);
   // the no-rows fallback still expands to the full sentence — never a dead end
@@ -261,7 +261,7 @@ test("the header follows the wait: idle → 'Awaiting …' + the idle note; work
   const body = RENDER.split("function renderBgTasks(")[1].split("\nfunction ")[0];
   assert.match(body, /if \(why\) \{[\s\S]*?const word = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, items\);/, "idle: today's label, agreeing in number with the chip");
   assert.match(body, /\} else \{[\s\S]*?lab\.textContent = "In the background · " \+ listBreakdown\(counted, keptN\);/,
-    "working: the same rows, worded as what they are; the header counts every row the list shows, the kept rows apart (T394)");
+    "working: the same rows, worded as what they are; the header counts every top-level row the list shows, then the kept subset (T394)");
   // the idle note is appended under a wait only — once at the end of the list, once in the no-rows fallback
   assert.match(body, /if \(why\) list\.appendChild\(bgIdleNote\(\)\);/);
   assert.match(body, /det\.appendChild\(bgIdleNote\(\)\);/);

--- a/ui/webview/bg-kinds.test.ts
+++ b/ui/webview/bg-kinds.test.ts
@@ -15,7 +15,7 @@ const FIXTURE = fs.readFileSync(path.resolve(process.cwd(), "..", "tools", "ui-v
 const fn = (name: string) => RENDER.slice(RENDER.indexOf("function " + name + "("), RENDER.indexOf("\n}\n", RENDER.indexOf("function " + name + "(")));
 const UI_RULES = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "CLAUDE.md"), "utf8");
 
-test("the header's words count the kept rows apart from the awaited breakdown, either alone when the other is empty", () => {
+test("the header's words: the breakdown of every row it is given, then how many of them wear the verdict; either alone when the other is empty", () => {
   const rows: AwaitRow[] = [{ kind: "agents", id: "a1", label: "Map the parser" }, { kind: "commands", id: "c1", label: "Build the docs" }, { kind: "watches", id: "w1", label: "the CI run" }];
   assert.equal(keptWord(0), "", "none kept: no word");
   assert.equal(keptWord(1), "1 kept running");
@@ -42,10 +42,12 @@ test("the sections are the kinds, in the rows' display order, and no section of 
     "every listed row is counted, the tracked tasks by kind (round two, medium: a box whose only row was a tracked task read a separator with nothing after it)");
   assert.match(body, /lab\.textContent = "In the background · " \+ listBreakdown\(counted, keptN\);/, "the working header counts every row it lists");
   assert.match(body, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(counted, keptN\);/, "…and the mixed idle header");
-  assert.match(body, /if \(kept\.length\) lab\.append\(" · " \+ listBreakdown\(kept\.map\(/, "…and the peer-named idle header counts the tracked rows below");
+  assert.match(body, /if \(kept\.length\) lab\.append\(" · " \+ listBreakdown\(counted, keptN\)\);/, "…and the peer-named idle header counts every listed row, the peer rows as peers (round four)");
+  assert.match(body, /counts every TOP-LEVEL row the list shows, by kind, awaited or not, a\n\s*\/\/ peer row as a peer/, "the rule's sentence names what it counts");
+  assert.match(body, /An agent's OWN waits, drawn as sub-rows under it, are the agent's and stay out of the count/, "…and what it excludes, and why");
   assert.match(body, /lab\.textContent = "Awaiting" \+ \(word \? " " \+ word : ""\) \+ " · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\) \+ \(kept\.length \? " · " \+ listBreakdown\(counted, keptN\) : ""\);/,
     "…and the one-kind idle header counts the rows beyond the wait's, by kind, with the kept subset (round three, low 3)");
-  assert.match(body, /THE HEADER'S RULE \(T394 round three, lows 1 and 2\): the leading word is the wait and its count is the awaited rows/, "the rule, stated where the header is built");
+  assert.match(body, /THE HEADER'S RULE \(T394 round three, lows 1 and 2; round four\): the leading word is the wait and its count is the awaited rows/, "the rule, stated where the header is built");
   assert.match(body, /subset of those rows wearing the judge's verdict, never a further partition/, "…the kept count is a subset, never a partition");
   assert.doesNotMatch(body, /listBreakdown\(items, keptN\)/, "no header reads the kernel's rows alone");
   const key = fn("awaitKey");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -13910,12 +13910,14 @@ function renderBgTasks() {
   const car = el("span", "bg-caret"); car.textContent = open ? "▾" : "▸"; head.appendChild(car);   // ▸ closed → ▾ open (expands DOWNWARD beneath the header)
   head.appendChild(el("span", "bg-dot"));
   const lab = el("span", "bg-fold-label");
-  // THE HEADER'S RULE (T394 round three, lows 1 and 2): the leading word is the wait and its count is the awaited rows (the chip's
-  // number); the breakdown after the separator counts EVERY row the list shows, by kind, awaited or not; "N kept running" is the
-  // subset of those rows wearing the judge's verdict, never a further partition. So "Awaiting 2 · 1 agent · 2 commands · 1 kept
-  // running" is a session waiting on two of three listed rows, one of them a command the judge called furniture. The one-kind idle
-  // header keeps the wait's own sentence and adds the breakdown only when the list shows rows beyond the wait's (else the word
-  // already counts them all).
+  // THE HEADER'S RULE (T394 round three, lows 1 and 2; round four): the leading word is the wait and its count is the awaited rows
+  // (the chip's number); the breakdown after the separator counts every TOP-LEVEL row the list shows, by kind, awaited or not, a
+  // peer row as a peer; "N kept running" is the subset of those rows wearing the judge's verdict, never a further partition. So
+  // "Awaiting 2 · 1 agent · 2 commands · 1 kept running" is a session waiting on two of three listed rows, one of them a command
+  // the judge called furniture. An agent's OWN waits, drawn as sub-rows under it, are the agent's and stay out of the count, as
+  // they stay out of the chip's (the session waits on the agent, the agent on them). The one-kind idle header and the peer-named
+  // one keep the wait's own words and add the breakdown only when the list shows rows beyond the wait's (else the word, or the
+  // names, already count them all).
   if (why) {
     // IDLE, waiting on the rows — the chip reads Awaiting and the header agrees with it in number: ONE rule
     // words both (awaitWord). The kernel's why leads with the verb ("waiting on a background command: …");
@@ -13934,7 +13936,7 @@ function renderBgTasks() {
         lab.appendChild(nm);
       });
       lab.append(" · " + why.replace(/^delegated to [^;]*;\s*/i, "").replace(/^(waiting on|awaiting)\s+/i, ""));
-      if (kept.length) lab.append(" · " + listBreakdown(kept.map((row) => ({ kind: row.kind || "commands", id: row.id, label: row.label })), keptN));   // the tracked rows below, counted (round two)
+      if (kept.length) lab.append(" · " + listBreakdown(counted, keptN));   // every listed row counted, the peer rows as peers (round four): the names alone count them otherwise
     } else if (groups.length > 1) {
       lab.textContent = "Awaiting " + word + " · " + listBreakdown(counted, keptN);   // mixed kinds: the number, then every listed row by kind, then the kept rows
     } else {

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -154,14 +154,15 @@ export function awaitBreakdown(items: readonly AwaitRow[] | null | undefined): s
   return groupRows(items).map((g) => g.rows.length + " " + rowWord(g.kind, g.rows.length)).join(" · ");
 }
 
-/** The header's words for the tracked tasks the kernel's rows do not name (T394, the user 2026-09-12): the judge audited
- *  their launch without a wait, so nobody waits on them; they list in their kind's section, dimmed, and the header counts
- *  them apart from the awaited breakdown ("1 kept running"), so it agrees with the list. "" when there are none. */
+/** The header's words for the rows wearing the judge's verdict (T394, the user 2026-09-12): tracked tasks the closer audited
+ *  past their launch without a wait, so nobody waits on them; they list in their kind's section, dimmed, and the header names
+ *  how many of its listed rows are such ("1 kept running"), a subset of the breakdown, never a further partition. "" when none. */
 export function keptWord(n: number): string {
   return n > 0 ? n + " kept running" : "";
 }
 
-/** The whole list in the header's words: the awaited breakdown, then the kept count; either alone when the other is empty. */
+/** The header's tail: the breakdown of every row it is given (the caller feeds it every top-level row the list shows, by kind),
+ *  then how many of them wear the verdict; either alone when the other is empty. */
 export function listBreakdown(items: readonly AwaitRow[] | null | undefined, kept: number): string {
   return [awaitBreakdown(items), keptWord(kept)].filter(Boolean).join(" · ");
 }


### PR DESCRIPTION
**Fix (T394 follow-up).** The box header's rule (the leading count is the awaited rows; the breakdown counts every listed row by kind; the kept count is the subset wearing the verdict) held in every branch but one: the peer-named idle header counted the tracked rows and not the peer row. It now counts every top-level row like the other branches, the peer as a peer. An awaited agent's own wait, drawn as a sub-row under it, stays out of the count as it stays out of the chip's, and the rule's sentence now says so instead of claiming every row. The doc comments of `keptWord` and `listBreakdown`, and the tests' prose, no longer describe the partition the rule replaced.

**Tests.** `tests/test_bg_kinds_browser.py` drives a session idle on a delegated peer with a kept service (red on main: the peer uncounted) and an awaited agent whose own wait is a sub-row (the header counts the top level only). Pins in `bg-kinds.test.ts` follow the branch and the sentence.
