### PR TITLE
The background box's comments and test prose say what the header does, and the peer-named header is pinned whole (T394 follow-up two)

### DIFF
--- a/tests/test_bg_kinds_browser.py
+++ b/tests/test_bg_kinds_browser.py
@@ -244,7 +244,7 @@ class ServedBgKinds(unittest.TestCase):
         # every listed row counted by kind (round two): the awaited command, the kept service, the placed command and the finished
         # service are four commands; only the running service wears the verdict (round one, medium 1 and low 1)
         self.assertEqual(d["header"], "In the background · 1 agent · 4 commands · 1 watch · 1 kept running",
-                         "the header counts every row it lists, the kept one apart: %r" % d["header"])
+                         "the header counts every row it lists, then how many wear the verdict: %r" % d["header"])
         for x, kind in ((agent, "agents"), (cmd, "commands"), (svc, "commands"), (placed, "commands"), (done, "commands"), (watch, "watches")):
             self.assertIn("bg-kind-" + kind, x["cls"].split(), "%s wears its kind: %r" % (x["label"], x["cls"]))
         self.assertIn("bg-kept", svc["cls"].split(), "the running service is the kept row: %r" % svc["cls"])
@@ -326,8 +326,9 @@ class ServedBgKinds(unittest.TestCase):
         pi = r["peerIdle"]
         # the sections in the rows' display order (agents, commands, watches, peers, timers): the kept service, then the peer
         self.assertEqual([(x["section"], x["label"], x["kept"]) for x in pi["rows"]], [("Commands", "Serve the docs preview", KEPT_WORD), ("Peers", "api", None)], "the kept service and the peer row: %r" % pi["rows"])
-        self.assertTrue(pi["header"].startswith("Awaiting api"), "the wait names the peer: %r" % pi["header"])
-        self.assertTrue(pi["header"].endswith(" · 1 command · 1 peer · 1 kept running"), "…then every listed row by kind, the peer as a peer, and the kept subset: %r" % pi["header"])
+        # the whole header once: the wait names the peer, the why with its delegated-to prefix stripped (a reply), then every listed row by
+        # kind (peers last, as the sections), then the kept subset
+        self.assertEqual(pi["header"], "Awaiting api · a reply · 1 command · 1 peer · 1 kept running", "the peer-named header, whole: %r" % pi["header"])
         ne = r["nested"]
         self.assertEqual([(x["label"], "bg-sub" in x["cls"].split()) for x in ne["rows"]], [("Map the notes-api parser", False), ("Run the parser test chunk", True)], "the agent, then its own wait as a sub-row: %r" % ne["rows"])
         self.assertEqual(ne["header"], "In the background · 1 agent", "the header counts the top level only: the sub-row is the agent's: %r" % ne["header"])

--- a/ui/webview/awaiting-rows.test.ts
+++ b/ui/webview/awaiting-rows.test.ts
@@ -375,7 +375,7 @@ test("the box draws an agent's waits as indented sub-rows in the SAME row vocabu
 });
 
 test("the header and the chip count the top level only: the breakdown reads `items`, and nested ids still keep their tracked task from listing twice as a leftover of its kind", () => {
-  assert.match(RENDER, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(counted, keptN\);/, "the mixed header's breakdown is every listed row, the kept rows counted apart (T394)");
+  assert.match(RENDER, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(counted, keptN\);/, "the mixed header's breakdown is every listed row by kind, then how many wear the verdict (T394)");
   assert.match(RENDER, /const word = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, items\);/, "the header word: top-level rows + the kernel's top-level count");
   assert.match(RENDER, /const itemIds = rowIds\(items\);/, "a task an agent's wait names is named, not a leftover");
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -13684,7 +13684,7 @@ const BG_RANK: Record<string, number> = { failed: 3, running: 2, completed: 1 };
 // T394 (the user 2026-09-12, from a screenshot of the fold with a section for tasks merely also running): a tracked task the kernel's rows do
 // not name is still a command or an agent, and what set it apart was a JUDGE'S VERDICT (the closer audited its launch without a
 // wait), not a kind. So it lists in its kind's section, dimmed, with the verdict as a muted suffix on the row (kept running, not
-// waited on), and the header counts it apart from the awaited breakdown; the section of its own, whose title said nothing of
+// waited on), and the header counts it with every listed row by kind, naming how many wear the verdict; the section of its own, whose title said nothing of
 // that, is gone. One hue per kind for the dot and the caption word (the sheet: bg-kind-*), status overriding for failed and
 // completed rows.
 const BG_KEPT_WORD = "· kept running, not waited on";
@@ -13945,7 +13945,7 @@ function renderBgTasks() {
   } else {
     // WORKING (or idle with nothing awaited — a service the session keeps around): the same rows, worded
     // as what they are, no idle note. The header counts every row the list shows (T394): the in-flight rows by
-    // kind, then the tracked tasks the kernel names no row for, apart, as the kept-running rows they are.
+    // kind, then the tracked tasks the kernel names no row for, counted with them by kind, the rows wearing the verdict named after.
     lab.textContent = "In the background · " + listBreakdown(counted, keptN);
   }
   head.appendChild(lab);

--- a/vscode-extension/src/bg-tasks.test.ts
+++ b/vscode-extension/src/bg-tasks.test.ts
@@ -23,7 +23,7 @@ test("the header is ONE line worded from the rows — 'Awaiting …' idle, 'In t
   // presentations at each turn boundary; one renderer now words the header from the same rows in both states
   assert.doesNotMatch(SRC, /count \+ " background tasks"/);
   assert.doesNotMatch(SRC, /"Background task · "/);
-  assert.match(SRC, /lab\.textContent = "In the background · " \+ listBreakdown\(counted, keptN\);/);   // every row the list shows, the kept rows counted apart (T394)
+  assert.match(SRC, /lab\.textContent = "In the background · " \+ listBreakdown\(counted, keptN\);/);   // every row the list shows by kind, then how many wear the verdict (T394)
   assert.match(SRC, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(counted, keptN\);/);
   // collapsed by default: when the fold isn't open, only the header renders
   assert.match(SRC, /const open = openFolds\.has\("bgfold:" \+ sid\);/);   // the ONE fold store since 2026-09-08 (was bgFoldOpen)


### PR DESCRIPTION
**Prose and a test (T394 follow-up two).** Two comments in `render.ts`, one pin message in `awaiting-rows.test.ts`, one pin comment in the extension's `bg-tasks.test.ts` and one assertion message in the served lab still described the header as counting the kept rows apart from the awaited breakdown, the framing the header's rule replaced; each now says the breakdown counts every listed row by kind and then names how many wear the verdict. The served lab asserts the peer-named header whole once (`Awaiting api · a reply · 1 command · 1 peer · 1 kept running`), so the why with its delegated-to prefix stripped is pinned.

Tier: docs
