### PR TITLE
The road counters' one locked helper and a write clearing the refusal slot, the memo store clearing a stale flip retirement and the flip asking the disk, the nudge gate's comments, the tick-job census and the sweep count (T398 and T391 follow-ups)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1545,7 +1545,7 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   `full:demoted` (an entry the gates demoted, the `g:<reason>` beside it:
   `rewrite` when the leaf's record entry was replaced by a from-zero read
   under a new generation, `nonleaf` when a lineage file moved),
-  `full:noDocument`, `full:refused` (a document that stood but did not verify,
+  `full:noDocument`, `full:noDir` (no checkpoint directory), `full:refused` (a document that stood but did not verify,
   its fallback reason counted), `bypass` (a pending cut armed on the session)
   and `fallback`; the same block rides `asmCheckpoint.parse` on GET /perf,
   beside `asmCheckpoint.removed`, the document files removed per reason (a

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -2582,7 +2582,7 @@ class FileAdapter:
                         if len(_TS_REPAIRED_SEEN) >= 4096:
                             _TS_REPAIRED_SEEN.clear()
                         _TS_REPAIRED_SEEN.add(u)
-                        _ASM_STATS["ts-repair"] = _ASM_STATS.get("ts-repair", 0) + 1
+                        _asm_stat("ts-repair")
                     if fsid not in _TS_REPAIR_NOTED:
                         if len(_TS_REPAIR_NOTED) >= 64:
                             _TS_REPAIR_NOTED.clear()   # re-arm — capped silence must not become
@@ -3233,7 +3233,7 @@ class FileAdapter:
                 # these would show up, since a silent clamp would hide a CLI write-order change. (The
                 # 2026-09-06 review: two goldens had pinned a landedT 30-40 s before the send, from a
                 # synthetic shape with no tool_result before the attachment.)
-                _ASM_STATS["landedT-clamp"] = _ASM_STATS.get("landedT-clamp", 0) + 1
+                _asm_stat("landedT-clamp")
                 landed_t = t
             atom["t"] = landed_t         # placed where the model READ it (T252d); `sentAt` keeps the send
         if ROMP_AUTO_RE.search(full):   # an AUTO-nudge → flag it, mirroring the native user-record path
@@ -4355,6 +4355,12 @@ def rewound_uuids(path, drop=True):
         return out
     _REWOUND_CACHE[key] = (count, gen, {"uuids": sorted(out)})   # the memo at the walk's own witness, dirty
     with _CKPT_LOCK:
+        r = _RETIRED_FOLDS.get(key)                        # a retirement still pending from a flip before this store is stale:
+        if r is not None:                                  #  the store is the newer event (T391 follow-up, low 7)
+            r.discard("rewoundUuids")
+            if not r:
+                _RETIRED_FOLDS.pop(key, None)
+    with _CKPT_LOCK:
         _FOLD_DIRTY.add(key)
     if drop and checkpoint_drop_writes_on():              # the quiescence drop over this frozen file writes the document from the
         with _JSONL_CACHE_LOCK:                           #  walk's own read and lets the records go (T362's drop, its budget and its
@@ -4426,6 +4432,13 @@ _ASM_KEYLOCKS = {}                 # key -> Lock; never pruned (a Lock is tiny, 
 #                                    key's lock mid-flight would let two folds interleave)
 _ASM_STATS = {"full": 0, "fold": 0, "serve": 0, "restore": 0, "bypass": 0, "fallback": 0}   # observability + tests (restore
 #                                                                                             seeded: a row without it means zero)
+
+
+def _asm_stat(key, n=1):
+    """One increment of the parse's road counters under _ASM_CKPT_LOCK (the lock the perf copy takes): every write goes through
+    here, so a judge parse and the pusher's parse never lose each other's increment (T398 follow-up, low 3)."""
+    with _ASM_CKPT_LOCK:
+        _ASM_STATS[key] = _ASM_STATS.get(key, 0) + n
 _ASM_WARNED = [False]
 _TS_REPAIR_NOTED = set()     # file stems already warned about a garbled stamp — once per file;
 #                              the cap CLEARS and re-arms (an occasional repeat note beats silence)
@@ -4437,7 +4450,7 @@ def _asm_demote(reason):
     """Count WHY a fold demoted to a full parse (g:<reason> in _ASM_STATS) and return None —
     the hit-rate diagnosis this cache lives or dies by, in prod and in the corpus replay."""
     k = "g:" + reason
-    _ASM_STATS[k] = _ASM_STATS.get(k, 0) + 1
+    _asm_stat(k)
     return None
 
 
@@ -4479,7 +4492,7 @@ def _asm_full(key, leaf_path, candidate_files, links, rompuuid, postal_index, sd
         while len(_ASM_CACHE) >= _ASM_CACHE_MAX:
             _ASM_CACHE.pop(next(iter(_ASM_CACHE)))   # oldest-used first; hot entries survive floods
         _ASM_CACHE[key] = entry
-    _ASM_STATS["full"] += 1
+    _asm_stat("full")
     return _asm_serve(entry)
 
 
@@ -4666,7 +4679,7 @@ def _asm_fold(entry, delta, leaf_recs, leaf_key, leaf_stem, rompuuid, postal_ind
     entry["recs"][leaf_key] = (ogen, obase, ocount + len(delta))   # commit LAST: a bail above re-slices the same
     ad._src[leaf_key] = leaf_recs                 #  delta next visit and the uuid gate demotes it
     ad._src_keys[leaf_key] = entry["recs"][leaf_key]
-    _ASM_STATS["fold"] += 1
+    _asm_stat("fold")
     return _asm_serve(entry)
 
 
@@ -5100,6 +5113,23 @@ def _retire_fold(path, name):
         _FOLD_DIRTY.add(key)
 
 
+def _doc_folds_on_disk(key):
+    """The fold shapes of `key`'s fold document as it sits on disk (a small JSON read, counted under documentBytes), {} with
+    none: what a retirement consults before any fold of this process has loaded the document."""
+    cp = _ckpt_file(key)
+    if cp is None or not cp.exists():
+        return {}
+    try:
+        text = cp.read_bytes(); _count_read(str(cp), len(text))
+        doc = json.loads(text.decode("utf-8"))
+    except (OSError, ValueError):
+        return {}
+    shapes = _doc_fold_shapes(doc.get("folds")) if isinstance(doc, dict) else {}
+    with _CKPT_LOCK:
+        _CKPT_DOC_FOLDS.setdefault(key, shapes)
+    return shapes
+
+
 def rewound_memo_forget(path):
     """Drop the incident scan's memo cursor for `path` (T391 follow-up, round one, low 2): a leaf that took the memo road while it
     had no assembly document carries a rewoundUuids cursor in its fold document; once its first compaction lands and the scan
@@ -5110,7 +5140,10 @@ def rewound_memo_forget(path):
     key = str(path)
     had = _REWOUND_CACHE.pop(key, None) is not None
     with _CKPT_LOCK:
-        on_disk = "rewoundUuids" in (_CKPT_DOC_FOLDS.get(key) or {})   # the document as last read or written carries the fold
+        shapes = _CKPT_DOC_FOLDS.get(key)
+    if shapes is None:                                    # no fold of this process has read or written the document yet (a fresh
+        shapes = _doc_folds_on_disk(key)                  #  process whose scan reaches the leaf first): ask the disk (low 8)
+    on_disk = "rewoundUuids" in (shapes or {})            # the document as last read or written carries the fold
     if had or on_disk:                                    # retire only at the FLIP, when there is something to retire: a leaf-road
         _retire_fold(key, "rewoundUuids")                 #  pass over a clean path retires nothing and dirties nothing (round two:
     #                                                        an unconditional retirement popped a memo stored later in the process
@@ -5639,6 +5672,9 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None, reason
         except OSError:
             return skip("write")
         entry["docWritten"] = True
+        with _ASM_CKPT_LOCK:
+            _ASM_CKPT_REFUSED.pop(os.path.realpath(str(leaf_path)), None)   # a fresh document stands: a later parse with none is
+        #                                                                       noDocument, not the old refusal (T398 follow-up, low 1)
         entry["docTurns"] = bool(turns_doc)              # the turns section was written (T323 stage 4c)
         entry["docNoTurns"] = _tree_key(tree) if (tree is not None and not turns_doc) else None   # …or this tree yields none
         with _ASM_CKPT_LOCK:
@@ -6135,7 +6171,7 @@ def _assemble(leaf_path, candidate_files, links, rompuuid, postal_index, sdk_hum
     if leaf_override:
         # A pending cut changes the walk anchor and is transient: always a plain full parse,
         # never cached — a cut parse's truncated emit state must not seed later folds.
-        _ASM_STATS["bypass"] += 1
+        _asm_stat("bypass")
         _mode("bypass")
         ad = FileAdapter(candidate_files, leaf_path, leaf_override=leaf_override, resume_links=links)
         ad.sdk_human = sdk_human
@@ -6157,7 +6193,7 @@ def _assemble(leaf_path, candidate_files, links, rompuuid, postal_index, sdk_hum
                     delta, leaf_recs = got
                     _asm_heal(entry, rompuuid, postal_index)
                     if not delta:
-                        _ASM_STATS["serve"] += 1
+                        _asm_stat("serve")
                         _mode("serve")
                         return _asm_serve(entry)
                     served = _asm_fold(entry, delta, leaf_recs, str(leaf_path),
@@ -6170,8 +6206,7 @@ def _assemble(leaf_path, candidate_files, links, rompuuid, postal_index, sdk_hum
             elif _CKPT_DIR_FN is not None:
                 served = _asm_restore(key, leaf_path, candidate_files, links, rompuuid, postal_index, sdk_human)
                 if served is not None:
-                    with _ASM_CKPT_LOCK:
-                        _ASM_STATS["restore"] += 1
+                    _asm_stat("restore")
                     _mode("restore")
                     return served
             # A full parse names its road (T398): an entry the gates DEMOTED (the g:<reason> beside it: the leaf's record
@@ -6188,13 +6223,12 @@ def _assemble(leaf_path, candidate_files, links, rompuuid, postal_index, sdk_hum
             else:                                         #  note unlinked it, so the stat below would have read it as none
                 cp_ = _asm_ckpt_file(leaf_path)
                 why = "noDocument" if cp_ is None or not cp_.exists() else "refused"
-            with _ASM_CKPT_LOCK:
-                _ASM_STATS["full:" + why] = _ASM_STATS.get("full:" + why, 0) + 1
+            _asm_stat("full:" + why)
             _mode("full")
             return _asm_full(key, leaf_path, candidate_files, links, rompuuid,
                              postal_index, sdk_human)
     except Exception as e:
-        _ASM_STATS["fallback"] += 1
+        _asm_stat("fallback")
         _mode("fallback")
         if not _ASM_WARNED[0] or _ASM_STATS["fallback"] in (10, 100, 1000, 10000):
             _ASM_WARNED[0] = True    # once, then at count milestones — a PERSISTENT fold bug

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -12904,7 +12904,7 @@ def _nudge_response_ready(turns, store, rec, gid, now):
 
 _nudge_gate_memo = {}            # sid -> (parse key, the shared view object, clears-log stat, unplanned): the gate's answer while its inputs stand
 _NUDGE_GATE_STATS = {"served": 0, "derived": 0, "failed": 0}   # /perf memos.nudgeGate: how often the walk re-derived the gate,
-#                                                                  and how often the derivation raised (the except leg: waves nothing through)
+#                                                                  and how often the derivation raised (the except leg answers not unplanned: nudges waved past the planner gate)
 _NUDGE_GATE_MEMO_MAX = 512
 
 
@@ -12924,7 +12924,7 @@ def _nudge_placement_gate(sid, turns, store):
     cached only when that view is STILL the current one after the derivation. The clears log's stat is taken
     BEFORE the derivation, so a boundary appended during it leaves a key the next cycle's stat cannot match.
     A parse the cache does not hold, or a store that is not the current shared view, is derived every time
-    and never cached. The exception path is unchanged: a gate that cannot be computed waves nothing through
+    and never cached. The exception path is unchanged: a gate that cannot be computed answers not unplanned (the walk proceeds on the closer gate alone: nudges waved past the planner gate, counted under failed)
     silently, and is never cached."""
     pk = jd._parse_entry(sid, turns=turns)     # the entry holding THESE turns, never the sid's newest slot (an agent
     #                                             view stored between the walk's parse and this read: review find)

--- a/tests/test_assembly_road_counters.py
+++ b/tests/test_assembly_road_counters.py
@@ -102,6 +102,44 @@ class AssemblyRoadCounters(Harness):
             self.assertIn(k, rows[0]["parse"], "seeded keys: a row without one means zero: %r" % rows[0]["parse"])
         self.assertEqual(rows[0]["parse"], em.asm_checkpoint_stats()["parse"], "the row is the perf block's parse, values and all")
 
+    def test_a_document_write_clears_the_refusal_slot(self):
+        """Follow-up, low 1: a refusal recorded by one parse was never cleared at a document write and the restore road returned
+        before the pop, so after a fresh document was written a later parse with NO document standing booked full:refused."""
+        records, sent = G.SINGLE_FILE["compaction_atom"]
+        path = self.write("slot", records(), sent=sent)
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
+        em._asm_ckpt_file(path).write_bytes(b"not a document")
+        self.fresh(); self._reset(); self.parse(path)
+        self.assertEqual(em.asm_checkpoint_stats()["parse"].get("full:refused"), 1)
+        em._asm_ckpt_note(path, "corrupt")                                  # a JUDGE read's refusal, recorded in the slot
+        self.assertTrue(self.doc(path), "a fresh document written")          # the write clears the slot
+        self.fresh(); modes = []; self.parse(path, modes); self.assertEqual(modes, ["restore"])   # the restore road: no pop
+        cp = em._asm_ckpt_file(path); cp.unlink(); cp.with_name(cp.name + ".meta").unlink(missing_ok=True)
+        self.fresh(); self._reset(); self.parse(path)
+        parse = em.asm_checkpoint_stats()["parse"]
+        self.assertEqual((parse.get("full:noDocument"), parse.get("full:refused", 0)), (1, 0), "no document standing: noDocument: %s" % parse)
+
+    def test_every_road_counter_write_goes_through_the_locked_helper(self):
+        """Follow-up, low 3: the lock covered two of ten writes; every increment goes through _asm_stat under _ASM_CKPT_LOCK."""
+        import inspect, re
+        src = inspect.getsource(em)
+        bare = [l.strip() for l in src.splitlines() if "_ASM_STATS[" in l and ("+=" in l or "= _ASM_STATS.get(" in l)
+                and "(key, 0) + n" not in l]                                # the helper's own line
+        self.assertEqual(bare, [], "bare writes: %r" % bare)
+        self.assertGreaterEqual(len(re.findall(r"_asm_stat\(", src)), 10)
+        self.assertIn("with _ASM_CKPT_LOCK:", inspect.getsource(em._asm_stat))
+
+    def test_the_boot_sweep_counts_the_documents_it_removes(self):
+        """Follow-up, low 6: `removed["sweep"]` had no test."""
+        records, sent = G.SINGLE_FILE["compaction_atom"]
+        path = self.write("swept", records(), sent=sent)
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
+        em._ASM_CKPT_STATS["removed"] = {}
+        os.unlink(path)                                                     # the transcript vanishes: the sweep removes its document
+        em.checkpoint_sweep()
+        self.assertEqual(em.asm_checkpoint_stats()["removed"], {"sweep": 1})
+        self.assertFalse(em._asm_ckpt_file(path).exists())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_first_cycle_stage_split.py
+++ b/tests/test_first_cycle_stage_split.py
@@ -62,7 +62,10 @@ class StageSplitUnit(unittest.TestCase):
         self.assertEqual(fresh["pusher"]["splitFailed"], 0, "seeded at zero: a row without it means zero, not an older kernel")
         self.assertEqual(fresh["stages_ms"]["prelude"], 0.0, "every stage listed at zero: %r" % sorted(fresh["stages_ms"])[:6])
         self.assertIn("jobs.interruptBlock", fresh["stages_ms"])
-        self.assertEqual(len(km._PerfStats.JOBS), 24, "the 24 tick jobs by name")
+        import re
+        named = set(re.findall(r"_job_stage\('(\w+)'", inspect.getsource(km._pusher_cycle_jobs)))
+        self.assertEqual(named, set(km._PerfStats.JOBS), "the JOBS tuple is the census of the wrapped tick jobs: a new job goes red here")
+        self.assertEqual(len(km._PerfStats.JOBS), len(set(km._PerfStats.JOBS)), "no name twice")
 
     def test_a_stages_bytes_are_the_readers_bytes_since_the_previous_boundary(self):
         km = self.km

--- a/tests/test_planner_lazy_unit_text.py
+++ b/tests/test_planner_lazy_unit_text.py
@@ -137,7 +137,7 @@ class LazyUnitText(Harness):
     def test_an_empty_late_read_retires_that_units_own_key_and_the_next_unit_still_plans(self):
         """Round four, medium: the retire wrote the collection loop's last-bound `key`, so a phantom unit's empty late read retired
         some OTHER unit (the next prompt's) and left the phantom's key absent: the prompt never planned and the nudge gate read
-        the phantom as unplanned. Driven through the real _plan_session: plan_units stubbed to yield a phantom work unit (its
+        the phantom as unplanned. Driven through the real _plan_session: plan_units stubbed to yield a phantom live unit (its
         late text empty) then a real human prompt unit; the phantom's own key is the one retired, the prompt plans."""
         km = kernel_module(); jd = km.jd
         fsid = "7a396000-2222-4333-8444-000000000396"

--- a/tests/test_rewind_memo.py
+++ b/tests/test_rewind_memo.py
@@ -44,6 +44,8 @@ class RewoundMemo(Harness):
 
     def fresh_process(self):
         self.fresh(); em.set_checkpoint_dir(lambda: self.ck)
+        with em._CKPT_LOCK:
+            em._COLD_FOLDS.clear()                        # a cold fold an earlier test left would keep checkpoint_has_work True (low 9)
         for c in list(em._FOLD_REG.values()):
             c.clear()
         em._REWOUND_CACHE.clear()
@@ -495,6 +497,54 @@ class RewoundMemo(Harness):
         rows = {k: v["bytes"] for k, v in em.record_cache_stats()["wholeReads"].items() if k.endswith("<-_per_file_rewound")}
         self.assertEqual(rows, {}, "the next process reads no whole file: %s" % em.record_cache_stats()["wholeReads"])
         self.assertEqual(em.rewound_memo_stats()["served"], 2, "both files served: %s" % em.rewound_memo_stats())
+
+    def test_a_fresh_store_for_the_memo_road_clears_a_pending_flip_retirement(self):
+        """Follow-up, low 7: a GENUINE flip retirement still pending when the session clears (the leaf becoming an anchor on the
+        memo road) popped the memo re-stored for the memo road out of the next write. The store is the newer event: it clears
+        the path's pending retirement."""
+        jd, fsid, path = self._own_leaf("pendflip", scenario="rewind_off_path")
+        self.fresh_process()
+        jd._per_file_rewound(fsid, [path])                                  # the memo road: a cursor
+        em.fold_records({}, path, list, lambda st, r: st, ckpt="pfFold"); self.assertTrue(em.checkpoint_write(path))
+        recs = G.SINGLE_FILE["rewind_off_path"][0]()
+        with open(path, "a") as fh:
+            for r in compacting_variant(recs, "pf")[len(recs):]:
+                fh.write(json.dumps(r) + "\n")
+        old = time.time() - 600; os.utime(path, (old, old))
+        tree = em.parse_session(path, rompuuid=fsid, name="impl", dir="/TESTDIR", candidate_files=[path], postal_log=[], now=NOW)
+        self.assertTrue(em.asm_checkpoint_write(path, fsid, tree=tree))
+        jd._per_file_rewound(fsid, [path])                                  # the flip: a genuine retirement, pending (no write yet)
+        self.assertIn("rewoundUuids", em._RETIRED_FOLDS.get(path, set()))
+        leaf2 = Path(path).with_name("7a391000-2222-4333-8444-000000000387.jsonl")   # the session clears: the leaf becomes the anchor
+        leaf2.write_text(json.dumps(G.uline(NOW + 5, "after the clear", "u_after2", None)) + "\n")
+        files = jd._judge_candidates(fsid, [str(leaf2)]); self.assertEqual(len(files), 2)
+        jd._per_file_rewound(fsid, files)                                   # the memo road stores a fresh cursor for the anchor
+        self.assertNotIn(path, em._RETIRED_FOLDS, "the store cleared the stale retirement")
+        em.fold_records({}, path, list, lambda st, r: st, ckpt="pfFold"); self.assertTrue(em.checkpoint_write(path))
+        self.assertIn("rewoundUuids", json.loads(em._ckpt_file(path).read_text())["folds"], "the fresh memo on disk")
+
+    def test_the_flip_consults_the_document_on_disk_when_no_fold_has_read_it_yet(self):
+        """Follow-up, low 8: in a fresh process where the scan reaches the leaf before any fold read its fold document, the tracker
+        had no entry, so the first write after the flip carried the dead cursor forward once. The forget asks the disk."""
+        jd, fsid, path = self._own_leaf("diskflip", scenario="rewind_off_path")
+        self.fresh_process()
+        jd._per_file_rewound(fsid, [path])
+        em.fold_records({}, path, list, lambda st, r: st, ckpt="dfFold"); self.assertTrue(em.checkpoint_write(path))
+        self.assertIn("rewoundUuids", json.loads(em._ckpt_file(path).read_text())["folds"])
+        recs = G.SINGLE_FILE["rewind_off_path"][0]()
+        with open(path, "a") as fh:
+            for r in compacting_variant(recs, "df")[len(recs):]:
+                fh.write(json.dumps(r) + "\n")
+        old = time.time() - 600; os.utime(path, (old, old))
+        tree = em.parse_session(path, rompuuid=fsid, name="impl", dir="/TESTDIR", candidate_files=[path], postal_log=[], now=NOW)
+        self.assertTrue(em.asm_checkpoint_write(path, fsid, tree=tree))
+        self.fresh_process()                                                # a fresh process: no fold has read the fold document
+        self.assertNotIn(path, em._CKPT_DOC_FOLDS)
+        jd._per_file_rewound(fsid, [path])                                  # the scan reaches the leaf first: the flip
+        self.assertIn("rewoundUuids", em._RETIRED_FOLDS.get(path, set()), "the disk said the document carries the fold")
+        em.fold_records({}, path, list, lambda st, r: st, ckpt="dfFold"); self.assertTrue(em.checkpoint_write(path))
+        d = json.loads(em._ckpt_file(path).read_text())
+        self.assertNotIn("rewoundUuids", d["folds"], "the first write after the flip omits the dead cursor: %r" % sorted(d["folds"]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix tier: nine review lows from the two previous perf and memo changes, in one PR; red-first per test at the base where the low is behavioural.

**From the road counters (T398).** A refusal recorded by a judge read was never cleared at a document write and the restore road returned before the pop, so after a fresh document was written a later parse with no document standing booked `full:refused`: the write clears the slot. Every `_ASM_STATS` write goes through one helper under the lock, so a judge parse and the pusher's parse never lose each other's increment. The nudge gate's code comment and docstring say what the except leg does (answers not unplanned: nudges waved past the planner gate, counted under `failed`), as the reference already did. The JOBS tuple is pinned as the census of the wrapped tick jobs in the source, so a new job goes red. The retire test's docstring names its phantom a live unit. The reference's parse list names `full:noDir`, and the sweep's `removed` count has a test.

**From the leaf-road memo (T391).** A genuine flip retirement still pending when the session cleared or forked before the next write popped the memo re-stored for the memo road: the store clears the path's pending retirement (the store is the newer event). In a fresh process where the scan reached a leaf before any fold had read its fold document, the forget saw no tracked shapes and the first write after the flip carried the dead cursor once: the forget asks the disk (a small counted read) when the tracker has no entry. The memo tests' harness clears cold folds, so their has-work assertions do not depend on test order.

**Red at the base:** the refusal slot ("Tuples differ: (0, 1) != (1, 0)": refused where noDocument was due), the pending flip retirement ("unexpectedly found ... {'rewoundUuids'} : the store cleared the stale retirement"), the disk consult ("'rewoundUuids' not found in set() : the disk said the document carries the fold"), the locked-helper census (ten bare writes listed). The tick-job census and the sweep count are pins, green at the base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)