### PR TITLE
A demoted assembly entry falls to the restore road for a descent, a rewrite or a moved lineage file, not straight to a whole parse (T402)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1541,7 +1541,9 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   bookkeeping could not close. The restart ledger's boot-health row carries
   the first cycle's `stages` beside `firstCycleS`, so a slow boot names its
   stage without the kernel alive, and `parse`, the assembly's road counters at
-  the first cycle's end (T398): `serve`, `fold`, `restore`, `full` with
+  the first cycle's end (T398): `serve`, `fold`, `restore` (with
+  `restore:afterDemote`, the restores taken over an entry the gates demoted
+  instead of a whole parse, T402), `full` with
   `full:demoted` (an entry the gates demoted, the `g:<reason>` beside it:
   `rewrite` when the leaf's record entry was replaced by a from-zero read
   under a new generation, `nonleaf` when a lineage file moved),

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -4446,11 +4446,20 @@ _TS_REPAIRED_SEEN = set()    # record uuids already counted in ts-repair — dis
 #                              not parse volume; races only overcount by one, acceptable
 
 
+_ASM_DEMOTE_TL = threading.local()   # the calling thread's last demotion reason: what _assemble reads to pick the road after it
+_ASM_RESTORE_AFTER_DEMOTE = ("descent", "rewrite", "nonleaf")   # the demotions the document still stands for (T402): the tail
+#                                   moved (a spur, a rewind, a fork), the leaf's record entry was replaced, a lineage file moved; the
+#                                   load's own checks refuse a document that no longer fits. Every other reason (a new boundary or
+#                                   summary in the tail, a prompt id, a skill link, a stamp out of order, ...) keeps the whole parse.
+
+
 def _asm_demote(reason):
     """Count WHY a fold demoted to a full parse (g:<reason> in _ASM_STATS) and return None —
-    the hit-rate diagnosis this cache lives or dies by, in prod and in the corpus replay."""
+    the hit-rate diagnosis this cache lives or dies by, in prod and in the corpus replay. The reason is
+    left on the thread for _assemble, which tries the restore road for the reasons the document still stands for."""
     k = "g:" + reason
     _asm_stat(k)
+    _ASM_DEMOTE_TL.reason = reason
     return None
 
 
@@ -6188,6 +6197,7 @@ def _assemble(leaf_path, candidate_files, links, rompuuid, postal_index, sdk_hum
                     _ASM_CACHE.pop(key, None)
                     _ASM_CACHE[key] = entry       # a served entry is a USED entry (LRU touch)
             if entry is not None:
+                _ASM_DEMOTE_TL.reason = None
                 got = _asm_gates(entry, leaf_path, candidate_files, links)
                 if got is not None:
                     delta, leaf_recs = got
@@ -6203,6 +6213,17 @@ def _assemble(leaf_path, candidate_files, links, rompuuid, postal_index, sdk_hum
                         return served
                 with _ASM_LOCK:                   # gate/invariance demotion: the entry is stale
                     _ASM_CACHE.pop(key, None)
+                # A demoted entry falls to the RESTORE road before the whole parse (T402): for a descent (the delta does not
+                # chain the new leaf to the old: an api_error spur, a rewind, a /clear fork in the tail), a rewrite or a moved
+                # lineage file, the document still stands for the pre-cut part and its own load checks refuse it when it does
+                # not fit; the tail read from the cut covers the moved leaf. The first instrumented boot (T398) paid two whole
+                # parses under g:descent inside the auto-nudge tick where a restore would have read the tail.
+                if _CKPT_DIR_FN is not None and getattr(_ASM_DEMOTE_TL, "reason", None) in _ASM_RESTORE_AFTER_DEMOTE:
+                    served = _asm_restore(key, leaf_path, candidate_files, links, rompuuid, postal_index, sdk_human)
+                    if served is not None:
+                        _asm_stat("restore"); _asm_stat("restore:afterDemote")
+                        _mode("restore")
+                        return served
             elif _CKPT_DIR_FN is not None:
                 served = _asm_restore(key, leaf_path, candidate_files, links, rompuuid, postal_index, sdk_human)
                 if served is not None:

--- a/tests/test_assembly_road_counters.py
+++ b/tests/test_assembly_road_counters.py
@@ -2,6 +2,7 @@
 """T398 (2026-09-12): a boot parsed two documented live leaves whole with no fallback counted, and nothing on GET /perf named the
 road the parse took. The assembly's road counters (serve, fold, restore, full with its reason, bypass, the g:<reason> demotions)
 ride asmCheckpoint.parse and the boot-health row, beside asmCheckpoint.removed, the document files removed per reason."""
+import json
 import os
 import sys
 import unittest
@@ -65,9 +66,10 @@ class AssemblyRoadCounters(Harness):
         self.parse(path)
         parse = em.asm_checkpoint_stats()["parse"]
         self.assertEqual(parse.get("g:rewrite"), 1, "%s" % parse)
-        self.assertEqual(parse.get("full:demoted"), 1, "%s" % parse)
+        self.assertEqual(parse.get("restore:afterDemote"), 1, "the demoted entry falls to the restore road (T402): %s" % parse)
+        self.assertEqual(parse.get("full:demoted", 0), 0, "%s" % parse)
         row = self._boot_row_parse()
-        self.assertEqual((row.get("g:rewrite"), row.get("full:demoted")), (1, 1), "the boot row's values: %r" % row)
+        self.assertEqual((row.get("g:rewrite"), row.get("restore:afterDemote")), (1, 1), "the boot row's values: %r" % row)
 
     def test_a_refused_standing_document_is_booked_as_refused_not_as_none(self):
         """Round one, medium: the restore's refusal unlinked the document before _assemble decided the reason by a stat, so a
@@ -140,6 +142,31 @@ class AssemblyRoadCounters(Harness):
         self.assertEqual(em.asm_checkpoint_stats()["removed"], {"sweep": 1})
         self.assertFalse(em._asm_ckpt_file(path).exists())
 
+    def test_a_demoted_entry_falls_to_the_restore_road_not_a_whole_parse(self):
+        """T402: an entry the gates demoted (here descent: a tail record re-parented off the leaf, the rewind shape) went
+        straight to a whole parse, consulting no document; the first instrumented boot paid two of them inside the auto-nudge
+        tick. The document still stands for the pre-cut part, so the restore road is tried first: g:descent booked, a restore
+        taken (restore:afterDemote), no whole read; the whole parse only when the restore returns None."""
+        records, sent = G.SINGLE_FILE["compaction_atom"]
+        path = self.write("descent", records(), sent=sent)
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
+        self.fresh(); tree = self.parse(path); self._reset()               # the entry stands, restored from the document
+        with em._JSONL_CACHE_LOCK:
+            em._RECORD_CACHE_STATS["wholeReads"] = {}
+        atoms = [a for t in tree["turns"] for a in t["atoms"] if a.get("uuid") and a.get("type") in ("user", "assistant")]
+        old_leaf = atoms[-1]; anchor = atoms[-3]                          # a record chained onto an EARLIER atom: off the leaf
+        t_late = max(float(a.get("t") or 0) for a in atoms) + 60
+        with open(path, "a") as fh:
+            fh.write(json.dumps(G.uline(t_late, "a rewind off the leaf", "u_rewound_tail", anchor["uuid"])) + "\n")
+        em._read_jsonl_entry(path, tail_ok=True)                           # the entry grows; the gates see the delta
+        self.parse(path)
+        parse = em.asm_checkpoint_stats()["parse"]
+        self.assertEqual(parse.get("g:descent"), 1, "the descent check demoted the entry: %s" % parse)
+        self.assertEqual(parse.get("restore:afterDemote"), 1, "and the restore road was taken: %s" % parse)
+        self.assertEqual(parse.get("full:demoted", 0), 0, "no whole parse: %s" % parse)
+        self.assertEqual({k: v for k, v in em.record_cache_stats()["wholeReads"].items()}, {}, "no whole read")
+        self.fresh(); whole = self.parse(path)
+        self.assertEqual([len(t["atoms"]) for t in whole["turns"]], [len(t["atoms"]) for t in self.parse(path)["turns"]])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix tier: a bug in the assembly's road choice with a test that fails before it. Cut from the nine-lows follow-up's head; main merged in at round three.

**What went wrong.** `_assemble` sent an entry the gates demoted straight to `_asm_full`, a whole read of the leaf, consulting no document; the first instrumented boot paid two whole parses under `g:descent` inside the auto-nudge tick where a restore would have read the tail.

**The change.** After the demotion pop, for the reasons the document still stands for (`descent`, `rewrite`, `nonleaf`), `_assemble` tries `_asm_restore` first, counted `restore:afterDemote`. Every read that seeds an adapter from a document (the boot restore, the restore after a demotion, `chain_membership`, `file_rewound`) first runs one predicate, `_tail_chains_onto_the_document`: the tail read from the cut must be a forest whose only root parent is the pre-cut spine tip, and only when the document's `tipChildless` bit says the writer proved, from the resolved graph at write time, that the tip had no pre-cut child (a compaction anchored on it counts). Every tail record bearing a uuid or a parentUuid key must REACH the tip through its parent chain within the tail, a compaction boundary through its effective parent (its anchor when known, else the preserved segment's tail, anchor or head for a truthy unknown anchor; an anchorless boundary is a root). A null, missing or self-linked parent, a cycle, a parent in the pre-cut interior or on an unproven tip, an unknown uuid, or a boundary re-anchored into the interior refuses to the whole parse (`restore:chainRefused`; `seeded:chainRefused` for the two readers, which then walk the file cold). The reference lists every road counter and demotion reason.

**Deploy note.** A document written before this change carries no `tipChildless` bit, so it is unproven: because the cut's own compaction boundary is the tail's first record and its effective parent is the tip, EVERY standing document is refused once at its next restore (one whole parse per session after deploy, booked `full:refused` in `asmCheckpoint.parse` and the boot-health row's `parse`), then rewritten with the bit at the next quiescence write. Expect the first boot after deploy to show `full:refused` equal to the number of restored sessions, and none after.

**Rounds.** One: the restore road after a descent demotion, a tail-chain check for descent alone. Two: one predicate for every restore-after-demote reason and the boot restore; twelve tail shapes against a cold parse; the rewrite leg drives the cache's own eviction, the nonleaf leg the load's lineage witness. Three: no exemption by record flag; the two seeded readers take the predicate. Four: the spine tip exempt only when childless (the live manual compaction chains its wrappers onto a childless tip, ten of thirteen corpus cases). Five: the childlessness decided at write time from `ad.parent_of` and stored in the document; a tail boundary held to its effective parent. Six: reachability instead of membership (a self-linked record, a boundary cycle, an anchorless boundary whose preserved segment names a tail record or the tip re-rooted the graph while every parent named a tail record; the seeded file_rewound named six records the cold walk files as clear); an anchorless boundary is a root.

**Tests** (`tests/test_assembly_road_counters.py`, each shape's served tree hydrated, stripped and compared to a cold whole parse): the twelve shapes on the descent road; the tip-fork shapes; the abandoned-compaction tip on all three roads; the re-anchored boundaries at boot and through both readers; the five re-rooting shapes on all three roads; the rewrite leg through the record cache's own eviction; the nonleaf leg through the lineage witness; the boot leg; the seeded readers against the cold walk. The golden round-trips (test_asm_checkpoint) keep every compaction scenario on the restore road, the detached manual compaction included.

**Module set the counts come from** (one executed run on the head, devbox, capped): tests/test_assembly_road_counters.py tests/test_asm_checkpoint.py tests/test_asm_index.py tests/test_asm_write_over_grown_entry.py tests/test_kernel_jsonl_cache.py tests/test_event_model_golden.py tests/test_lazy_body_readers.py tests/test_first_cycle_stage_split.py tests/test_restart_phases.py tests/test_fold_checkpoints.py tests/test_rewind_memo.py tests/test_judge.py tests/test_kernel.py tests/test_chat_fixed_cost_memos.py tests/test_boot_parse_gating.py.

Seven: a uuid repeated in the tail or reusing a pre-cut record's refuses outright (the parse keeps the last record's parent where a memo keyed by uuid kept the first's; a reuse of a pre-cut uuid closes a cycle across the spine), and the gates' known-uuid check covers a restored entry's pre-cut uuids, so such a reuse demotes to the whole parse instead of folding a tree a cold parse would clear. One standing disagreement with the cold oracle remains outside the rule and is named in the reference: a tail record whose stamp precedes the cut or the tip chains soundly, but the write-time stamp-order guard is not re-checked; identical at the merge-base.

Eight: a uuid repeated within the tail is resolved as the parse resolves it (the last record's node and parent) and reachability decides it, instead of refusing; a count-only scan of the local transcripts (15,692 files, no content read) found 545 with a repeated uuid (3.5 percent, 54,369 repeated records), 53,507 of them user records repeating with the same parent and 7 in all repeating with a different parent, so the blanket refusal cost the restore on one session in thirty at every boot and reader call. A tail uuid reusing a pre-cut record's still refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

